### PR TITLE
Timbl bugfix - fix problem of source pane not getting content type of document

### DIFF
--- a/contact/contactPane.js
+++ b/contact/contactPane.js
@@ -1313,7 +1313,7 @@ module.exports = {
         console.log('Logged in as ' + context.me)
         me = context.me
       }, err => {
-        div.appendChild(UI.utils.errorMessageBlock(err))
+        div.appendChild(UI.widgets.errorMessageBlock(err))
       })
     } else {
       // console.log("(Your webid is "+ me +")")

--- a/source/sourcePane.js
+++ b/source/sourcePane.js
@@ -121,7 +121,7 @@ const thisPane = {
         setEditable()
       })
       .catch(function (err) {
-        div.appendChild(UI.utils.errorMessageBlock(dom, 'Error saving back: ' + err))
+        div.appendChild(UI.widgets.errorMessageBlock(dom, 'Error saving back: ' + err))
       })
     }
 

--- a/source/sourcePane.js
+++ b/source/sourcePane.js
@@ -146,13 +146,13 @@ const thisPane = {
         var contentType, allowed, eTag
         if (response.headers && response.headers.get('content-type')) {
           contentType = response.headers.get('content-type') // Should work but headers may be empty
-          allow = response.headers.get('allow')
+          allowed = response.headers.get('allow')
           eTag = response.headers.get('etag')
         }
 
-        let reqs = kb.each(null , kb.sym('http://www.w3.org/2007/ont/link#requestedURI'), subject.uri)
-        reqs.forEach( req => {
-          let rrr = kb.any(req , kb.sym('http://www.w3.org/2007/ont/link#response'))
+        let reqs = kb.each(null, kb.sym('http://www.w3.org/2007/ont/link#requestedURI'), subject.uri)
+        reqs.forEach(req => {
+          let rrr = kb.any(req, kb.sym('http://www.w3.org/2007/ont/link#response'))
           if (rrr) {
             contentType = kb.anyValue(rrr, UI.ns.httph('content-type'))
             allowed = kb.anyValue(rrr, UI.ns.httph('allow'))

--- a/source/sourcePane.js
+++ b/source/sourcePane.js
@@ -144,12 +144,12 @@ const thisPane = {
 
         setUnedited()
         var contentType, allowed, eTag
-        if (response.headers || response.headers.get('content-type')) {
+        if (response.headers && response.headers.get('content-type')) {
           contentType = response.headers.get('content-type') // Should work but headers may be empty
           allow = response.headers.get('allow')
           eTag = response.headers.get('etag')
         }
-        // let rrr = kb.any(response.req, kb.sym('http://www.w3.org/2007/ont/link#response'))
+
         let reqs = kb.each(null , kb.sym('http://www.w3.org/2007/ont/link#requestedURI'), subject.uri)
         reqs.forEach( req => {
           let rrr = kb.any(req , kb.sym('http://www.w3.org/2007/ont/link#response'))

--- a/source/sourcePane.js
+++ b/source/sourcePane.js
@@ -64,7 +64,8 @@ const thisPane = {
     var readonly = true
     var editing = false
     var broken = false
-    var contentType, eTag // Note it when we read and use it when we save
+    // Set in refresh()
+    var contentType, allowed, eTag // Note it when we read and use it when we save
 
     var div = dom.createElement('div')
     div.setAttribute('class', 'sourcePane')
@@ -143,7 +144,6 @@ const thisPane = {
         textArea.value = desc
 
         setUnedited()
-        var contentType, allowed, eTag
         if (response.headers && response.headers.get('content-type')) {
           contentType = response.headers.get('content-type') // Should work but headers may be empty
           allowed = response.headers.get('allow')


### PR DESCRIPTION
Had to switch to being able to take from previous HTTP transactions, as (a) the webOperation function doesn't save metadata in the store and (b) the response object in Chrome in this situation has response.headers as empty {} 