### PR TITLE
Use foaf:name in profile editor

### DIFF
--- a/contact/individualForm.js
+++ b/contact/individualForm.js
@@ -1,6 +1,7 @@
 module.exports = `
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix ui: <http://www.w3.org/ns/ui#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix : <#>.
 
 <http://www.w3.org/2006/vcard/ns#Individual>
@@ -22,9 +23,8 @@ module.exports = `
 
     <#fullNameField>
         a <http://www.w3.org/ns/ui#SingleLineTextField> ;
-        ui:label "Name";
         <http://www.w3.org/ns/ui#maxLength> "128" ;
-        <http://www.w3.org/ns/ui#property> <http://www.w3.org/2006/vcard/ns#fn> ;
+        <http://www.w3.org/ns/ui#property> foaf:name ;
         <http://www.w3.org/ns/ui#size> "40" .
 
     <#roleField>

--- a/contact/individualForm.ttl
+++ b/contact/individualForm.ttl
@@ -1,5 +1,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix ui: <http://www.w3.org/ns/ui#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix : <#>.
 
 <http://www.w3.org/2006/vcard/ns#Individual>
@@ -21,9 +22,8 @@
 
     <#fullNameField>
         a <http://www.w3.org/ns/ui#SingleLineTextField> ;
-        ui:label "Name";
         <http://www.w3.org/ns/ui#maxLength> "128" ;
-        <http://www.w3.org/ns/ui#property> <http://www.w3.org/2006/vcard/ns#fn> ;
+        <http://www.w3.org/ns/ui#property> foaf:name ;
         <http://www.w3.org/ns/ui#size> "40" .
 
     <#roleField>


### PR DESCRIPTION
When preparing the demo for the Decentralized Web Summit, we noticed that:
- a fresh user's profile on node-solid-server uses `foaf:name`
- the profile editor of solid-panes uses `vcard:fn`

The result is that the profile editor will not show the person's name.

## Possible solutions
### Change the profile editor to use `foaf:name` instead _(= this PR)_
Problem: FOAF does not have all properties that VCARD has, so we end up with a mixture.

### Change node-solid-server to default to `vcard:fn`
Problem: FOAF is popular, it seems to be assumed in the footprint of a FOAF profile

### Make the editor accept both `vcard:fn` and `foaf:name`
Problem: I don't know how to model this with `http://www.w3.org/ns/ui#`, maybe this isn't possible yet.

### Change node-solid-server to default to use both `vcard:fn` and `foaf:name`
Problem: redundancy / inconsistencies?

### Use reasoning to derive one property from the other
That's what I'm doing to publish my profile (https://ruben.verborgh.org/articles/queryable-research-data/#reason).
Problem: I think this is the way forward for the future (query in one ontology and have reasoning derive the rest), but is likely too complex for now.