### PR TITLE
Refinement of test setup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,13 @@
     "@typescript-eslint"
   ],
   "rules": {
-    "@typescript-eslint/no-unused-vars": "warn"
+    "no-unused-vars": ["warn", {
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_"
+    }],
+    "@typescript-eslint/no-unused-vars": ["warn", {
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_"
+    }]
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,20 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
   testEnvironment: 'node',
-};
+  collectCoverage: true,
+  // For some reason Jest is not measuring coverage without the below option.
+  // Unfortunately, despite `!(.test)`, it still measures coverage of test files as well:
+  forceCoverageMatch: ['**/*!(.test).ts'],
+  // Since we're only measuring coverage for TypeScript (i.e. added with test infrastructure in place),
+  // we can be fairly strict. However, if you feel that something is not fit for coverage,
+  // mention why in a comment and mark it as ignored:
+  // https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "watch": "npm run clean && webpack --progress --colors --watch --mode=\"development\"",
     "clean": "rm -rf dist/",
     "lint": "eslint \"**/*.ts\"",
-    "test": "npm run lint && jest --onlyChanged --watch"
+    "test-watch": "npm run lint && jest --onlyChanged --watch",
+    "test": "npm run lint && jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "npm run clean && webpack --progress --colors --watch --mode=\"development\"",
     "clean": "rm -rf dist/",
     "lint": "eslint \"**/*.ts\"",
-    "test": "npm run lint && jest"
+    "test": "npm run lint && jest --onlyChanged --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "npm run clean && webpack --progress --colors --watch --mode=\"development\"",
     "clean": "rm -rf dist/",
     "lint": "eslint \"**/*.ts\"",
-    "test": "npm run lint; jest"
+    "test": "npm run lint && jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds:

- ESLint permission to prefix unused variable with an underscore. This is not allowed by default by Standard JS, but since a lot of current code does not work with named parameters, and we sometimes need the third but not the second argument to a function, being able to indicate that the second variable is unused is sometimes necessary.
- Sets test coverage thresholds to 100%, only applying to TypeScript (i.e. new) files. Note that not all lines actually have to be covered - see [here](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md) for instructions on how to indicate that you decided not to add tests for specific lines of code.
- Run Jest in watch mode by default, allowing you to keep it running while working on tests, and automatically re-executing when you change the tests.