### PR TITLE
Proposal for refactoring

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+typings/rdflib

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ install:
   - npm install
 script:
   - npm test
+  # Make sure it still builds successfully - the build isn't actually used yet:
+  - npm run build

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ register(require('issue-pane'))
 register(require('contacts-pane'))
 
 register(require('./pad/padPane').default)
+register(require('./scratchpad/paneWrapper').default)
 // register(require('./argument/argumentPane.js')) // A position in an argument tree
 
 register(require('./transaction/pane.js'))

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ let register = panes.register
 register(require('issue-pane'))
 register(require('contacts-pane'))
 
-register(require('./pad/padPane.js'))
+register(require('./pad/padPane').default)
 // register(require('./argument/argumentPane.js')) // A position in an argument tree
 
 register(require('./transaction/pane.js'))

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   collectCoverage: true,
   // For some reason Jest is not measuring coverage without the below option.
   // Unfortunately, despite `!(.test)`, it still measures coverage of test files as well:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,6 +1865,27 @@
         }
       }
     },
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.4.tgz",
@@ -2538,8 +2559,7 @@
     "@types/rdflib": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@types/rdflib/-/rdflib-0.17.1.tgz",
-      "integrity": "sha512-5vvVZrRYeVLmaG76BjJvlIMkWUcyn2fWvCoylVvm2yw5Sxun0i7c093wK37MNcwMZOyHzjGv77PGKbLhnpGv/Q==",
-      "dev": true
+      "integrity": "sha512-5vvVZrRYeVLmaG76BjJvlIMkWUcyn2fWvCoylVvm2yw5Sxun0i7c093wK37MNcwMZOyHzjGv77PGKbLhnpGv/Q=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "solid-ui": "file://../../solid/solid-ui"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.4.4",
     "@solid/better-simple-slideshow": "^0.1.0",
     "chat-pane": ">=1.2.7",
     "contacts-pane": "^1.0.3",

--- a/pad/padPane.ts
+++ b/pad/padPane.ts
@@ -1,10 +1,12 @@
+import UI from 'solid-ui'
+import { PaneDefinition } from '../types'
+import $rdf, { NamedNode } from 'rdflib'
 /*   pad Pane
 **
 */
-var UI = require('solid-ui')
 var ns = UI.ns
 
-module.exports = {
+const paneDef: PaneDefinition = {
   // icon:  (module.__dirname || __dirname) + 'images/ColourOn.png',
   icon: UI.icons.iconBase + 'noun_79217.svg',
 
@@ -22,7 +24,7 @@ module.exports = {
 
   mintClass: ns.pad('Notepad'),
 
-  mintNew: function (newPaneOptions) {
+  mintNew: function (newPaneOptions: any) {
     var kb = UI.store
     var ns = UI.ns
     var updater = kb.updater
@@ -51,7 +53,7 @@ module.exports = {
         newPadDoc,
         kb.statementsMatching(undefined, undefined, undefined, newPadDoc),
         'text/turtle',
-        function (uri2, ok, message) {
+        function (uri2: string, ok: boolean, message: string) {
           if (ok) {
             resolve(newPaneOptions)
           } else {
@@ -62,15 +64,15 @@ module.exports = {
     })
   },
   // and follow instructions there
-  render: function (subject, dom, paneOptions) {
+  render: function (subject, dom, paneOptions: any) {
     // Utility functions
-    var complainIfBad = function (ok, message) {
+    var complainIfBad = function (ok: boolean, message: string) {
       if (!ok) {
         div.appendChild(UI.widgets.errorMessageBlock(dom, message, 'pink'))
       }
     }
 
-    var clearElement = function (ele) {
+    var clearElement = function (ele: HTMLElement) {
       while (ele.firstChild) {
         ele.removeChild(ele.firstChild)
       }
@@ -81,7 +83,7 @@ module.exports = {
 
     // Two variations of ACL for this app, public read and public read/write
     // In all cases owner has read write control
-    var genACLtext = function (docURI, aclURI, allWrite) {
+    var genACLtext = function (docURI: string, aclURI: string, allWrite: boolean) {
       var g = $rdf.graph()
       var auth = $rdf.Namespace('http://www.w3.org/ns/auth/acl#')
       var a = g.sym(aclURI + '#a1')
@@ -102,7 +104,8 @@ module.exports = {
       if (allWrite) {
         g.add(a, auth('mode'), auth('Write'), acl)
       }
-      return $rdf.serialize(acl, g, aclURI, 'text/turtle')
+      // TODO: Figure out why `serialize` isn't on the type definition according to TypeScript:
+      return ($rdf as any).serialize(acl, g, aclURI, 'text/turtle')
     }
 
     /**
@@ -112,7 +115,7 @@ module.exports = {
      *
      * @returns {Promise<Response>}
      */
-    var setACL = function setACL (docURI, allWrite, callbackFunction) {
+    var setACL = function setACL (docURI: string, allWrite: boolean, callbackFunction: Function) {
       var aclDoc = kb.any(kb.sym(docURI),
         kb.sym('http://www.iana.org/assignments/link-relations/acl')) // @@ check that this get set by web.js
 
@@ -120,13 +123,13 @@ module.exports = {
         var aclText = genACLtext(docURI, aclDoc.uri, allWrite)
 
         return fetcher.webOperation('PUT', aclDoc.uri, { data: aclText, contentType: 'text/turtle' })
-          .then(result => callbackFunction(true))
-          .catch(err => {
+          .then((_result: any) => callbackFunction(true))
+          .catch((err: Error) => {
             callbackFunction(false, err.message)
           })
       } else {
         return fetcher.load(docURI)
-          .catch(err => {
+          .catch((err: Error) => {
             callbackFunction(false, 'Getting headers for ACL: ' + err)
           })
           .then(() => {
@@ -142,8 +145,8 @@ module.exports = {
 
             return fetcher.webOperation('PUT', aclDoc.uri, { data: aclText, contentType: 'text/turtle' })
           })
-          .then(result => callbackFunction(true))
-          .catch(err => {
+          .then((_result: any) => callbackFunction(true))
+          .catch((err: Error) => {
             callbackFunction(false, err.message)
           })
       }
@@ -162,9 +165,9 @@ module.exports = {
     }
 
     // Option of either using the workspace system or just typing in a URI
-    var showBootstrap = function showBootstrap (thisInstance, container, noun) {
+    var showBootstrap = function showBootstrap (thisInstance: any, container: HTMLElement, noun: string) {
       var div = clearElement(container)
-      var appDetails = {'noun': 'notepad'}
+      var appDetails = { 'noun': 'notepad' }
       div.appendChild(UI.authn.newAppInstance(
         dom, appDetails, initializeNewInstanceInWorkspace))
 
@@ -175,15 +178,15 @@ module.exports = {
         'Give the URL of the directory where you would like the data stored.'
       var baseField = div.appendChild(dom.createElement('input'))
       baseField.setAttribute('type', 'text')
-      baseField.size = 80 // really a string
-      baseField.label = 'base URL'
+      baseField.size = 80; // really a string
+      (baseField as any).label = 'base URL'
       baseField.autocomplete = 'on'
 
       div.appendChild(dom.createElement('br')) // @@
 
       var button = div.appendChild(dom.createElement('button'))
       button.textContent = 'Start new ' + noun + ' at this URI'
-      button.addEventListener('click', function (e) {
+      button.addEventListener('click', function (_e) {
         var newBase = baseField.value
         if (newBase.slice(-1) !== '/') {
           newBase += '/'
@@ -193,7 +196,7 @@ module.exports = {
     }
 
     //  Create new document files for new instance of app
-    var initializeNewInstanceInWorkspace = function (ws) {
+    var initializeNewInstanceInWorkspace = function (ws: NamedNode) {
       var newBase = kb.any(ws, ns.space('uriPrefix'))
       if (!newBase) {
         newBase = ws.uri.split('#')[0]
@@ -210,7 +213,7 @@ module.exports = {
       initializeNewInstanceAtBase(thisInstance, newBase)
     }
 
-    var initializeNewInstanceAtBase = function (thisInstance, newBase) {
+    var initializeNewInstanceAtBase = function (thisInstance: any, newBase: string) {
       var here = $rdf.sym(thisInstance.uri.split('#')[0])
       var base = here // @@ ???
 
@@ -227,35 +230,35 @@ module.exports = {
 
       // $rdf.log.debug("\n Ready to put " + kb.statementsMatching(undefined, undefined, undefined, there)); //@@
 
-      var agenda = []
+      var agenda: Function[] = []
 
       var f //   @@ This needs some form of visible progress bar
       for (f = 0; f < toBeCopied.length; f++) {
         var item = toBeCopied[f]
-        var fun = function copyItem (item) {
+        var fun = function copyItem (item: any) {
           agenda.push(function () {
             var newURI = newBase + item.local
             console.log('Copying ' + base + item.local + ' to ' + newURI)
 
             var setThatACL = function () {
-              setACL(newURI, false, function (ok, message) {
+              setACL(newURI, false, function (ok: boolean, message: string) {
                 if (!ok) {
                   complainIfBad(ok, 'FAILED to set ACL ' + newURI + ' : ' + message)
                   console.log('FAILED to set ACL ' + newURI + ' : ' + message)
                 } else {
-                  agenda.shift()() // beware too much nesting
+                  agenda.shift()!() // beware too much nesting
                 }
               })
             }
 
             kb.fetcher.webCopy(base + item.local, newBase + item.local, item.contentType)
               .then(() => UI.authn.checkUser())
-              .then(webId => {
+              .then((webId: string) => {
                 me = webId
 
                 setThatACL()
               })
-              .catch(err => {
+              .catch((err: Error) => {
                 console.log('FAILED to copy ' + base + item.local + ' : ' + err.message)
                 complainIfBad(false, 'FAILED to copy ' + base + item.local + ' : ' + err.message)
               })
@@ -281,9 +284,9 @@ module.exports = {
           newPadDoc,
           kb.statementsMatching(undefined, undefined, undefined, newPadDoc),
           'text/turtle',
-          function (uri2, ok, message) {
+          function (_uri2: string, ok: boolean, message: string) {
             if (ok) {
-              agenda.shift()()
+              agenda.shift()!()
             } else {
               complainIfBad(ok, 'FAILED to save new notepad at: ' + newPadDoc.uri + ' : ' + message)
               console.log('FAILED to save new notepad at: ' + newPadDoc.uri + ' : ' + message)
@@ -293,9 +296,9 @@ module.exports = {
       })
 
       agenda.push(function () {
-        setACL(newPadDoc.uri, true, function (ok, body) {
+        setACL(newPadDoc.uri, true, function (ok: boolean, body: string) {
           complainIfBad(ok, 'Failed to set Read-Write ACL on pad data file: ' + body)
-          if (ok) agenda.shift()()
+          if (ok) agenda.shift()!()
         })
       })
 
@@ -309,18 +312,18 @@ module.exports = {
           "<br/><br/><a href='" + newIndexDoc.uri + "'>Go to new pad</a>"
       })
 
-      agenda.shift()()
+      agenda.shift()!()
       // Created new data files.
     }
 
     //  Update on incoming changes
-    var showResults = function (exists) {
+    var showResults = function (exists: boolean) {
       console.log('showResults()')
 
       me = UI.authn.currentUser()
 
       UI.authn.checkUser()
-        .then(webId => {
+        .then((webId: string) => {
           me = webId
         })
 
@@ -340,11 +343,11 @@ module.exports = {
 
     // Read or create empty data file
     var loadPadData = function () {
-      fetcher.nowOrWhenFetched(padDoc.uri, undefined, function (ok, body, response) {
+      fetcher.nowOrWhenFetched(padDoc.uri, undefined, function (ok: boolean, body: string, response: any) {
         if (!ok) {
           if (response.status === 404) { // /  Check explicitly for 404 error
             console.log('Initializing results file ' + padDoc)
-            updater.put(padDoc, [], 'text/turtle', function (uri2, ok, message) {
+            updater.put(padDoc, [], 'text/turtle', function (_uri2: string, ok: boolean, message: string) {
               if (ok) {
                 clearElement(naviMain)
                 showResults(false)
@@ -353,10 +356,10 @@ module.exports = {
                 console.log('FAILED to craete results file at: ' + padDoc.uri + ' : ' + message)
               }
             })
-          } else {  // Other error, not 404 -- do not try to overwite the file
+          } else { // Other error, not 404 -- do not try to overwite the file
             complainIfBad(ok, 'FAILED to read results file: ' + body)
           }
-        } else {  // Happy read
+        } else { // Happy read
           clearElement(naviMain)
           if (kb.holds(subject, ns.rdf('type'), ns.wf('TemplateInstance'))) {
             showBootstrap(subject, naviMain, 'pad')
@@ -374,7 +377,7 @@ module.exports = {
     var fetcher = UI.store.fetcher
     var updater = UI.store.updater
     var ns = UI.ns
-    var me
+    var me: any
 
     var PAD = $rdf.Namespace('http://www.w3.org/ns/pim/pad#')
 
@@ -411,12 +414,12 @@ module.exports = {
 
     var naviMenu = structure.appendChild(dom.createElement('tr'))
     naviMenu.setAttribute('class', 'naviMenu')
-//    naviMenu.setAttribute('style', 'margin-top: 3em;');
+    // naviMenu.setAttribute('style', 'margin-top: 3em;');
     naviMenu.appendChild(dom.createElement('td')) // naviLeft
     naviMenu.appendChild(dom.createElement('td'))
     naviMenu.appendChild(dom.createElement('td'))
 
-    var options = { statusArea: statusArea, timingArea: naviMiddle1 }
+    var options: any = { statusArea: statusArea, timingArea: naviMiddle1 }
 
     loadPadData()
 
@@ -424,3 +427,5 @@ module.exports = {
   }
 }
 // ends
+
+export default paneDef

--- a/scratchpad/__snapshots__/data.test.ts.snap
+++ b/scratchpad/__snapshots__/data.test.ts.snap
@@ -1,0 +1,620 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getInitialisationStatements() should include author information if available 1`] = `
+Array [
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#Notepad",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "Scratchpad (1/1/1970)",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/title",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-user",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/author",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+]
+`;
+
+exports[`getInitialisationStatements() should properly initialise a new notepad 1`] = `
+Array [
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#Notepad",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "Scratchpad (1/1/1970)",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/title",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl#this",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://localhost:8443/public/0/index.ttl",
+    },
+  },
+]
+`;
+
+exports[`getSetContentsStatements() should clear previous content, if any 1`] = `
+Array [
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "Existing content",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://arbitrary-line",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://arbitrary-line",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://arbitrary-line",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+]
+`;
+
+exports[`getSetContentsStatements() should include author information if available 1`] = `
+Array [
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "Arbitrary content",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://rdfs.org/sioc/ns#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-user",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/author",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+]
+`;
+
+exports[`getSetContentsStatements() should properly set a notepad's contents 1`] = `
+Array [
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://rdfs.org/sioc/ns#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line1",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line0",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "Here's some arbitrary",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://rdfs.org/sioc/ns#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line1",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line1",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line2",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line1",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "multiline",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://rdfs.org/sioc/ns#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line2",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line2",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line3",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line2",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "content",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://rdfs.org/sioc/ns#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line3",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line3",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line4",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line3",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "termType": "Literal",
+      "value": "    ",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://rdfs.org/sioc/ns#content",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line4",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": Literal {
+      "datatype": NamedNode {
+        "termType": "NamedNode",
+        "value": "http://www.w3.org/2001/XMLSchema#dateTime",
+      },
+      "termType": "Literal",
+      "value": "1970-01-01T00:00:00Z",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://purl.org/dc/elements/1.1/created",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line4",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+  Statement {
+    "object": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+    "predicate": NamedNode {
+      "termType": "NamedNode",
+      "value": "http://www.w3.org/ns/pim/pad#next",
+    },
+    "subject": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad_line4",
+    },
+    "why": NamedNode {
+      "termType": "NamedNode",
+      "value": "https://mock-pad",
+    },
+  },
+]
+`;

--- a/scratchpad/__snapshots__/view.test.ts.snap
+++ b/scratchpad/__snapshots__/view.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`View mode should properly render the pad's contents 1`] = `"<div>First line<br>Second line<br></div>"`;
+exports[`View mode should properly render the pad's contents 1`] = `"<div>First line<br>Second line<br><hr><small></small></div>"`;

--- a/scratchpad/__snapshots__/view.test.ts.snap
+++ b/scratchpad/__snapshots__/view.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`View mode should properly render the pad's contents 1`] = `"<div>First line<br>Second line<br></div>"`;

--- a/scratchpad/data.test.ts
+++ b/scratchpad/data.test.ts
@@ -1,0 +1,133 @@
+/* eslint-env jest */
+import $rdf from 'rdflib'
+import { getInitialisationStatements, getSetContentsStatements, getContents, isPad, getTitle } from './data'
+import vocab from 'solid-namespace'
+
+const ns = vocab($rdf)
+
+describe('getInitialisationStatements()', () => {
+  it('should properly initialise a new notepad', async () => {
+    const mockStore = $rdf.graph()
+    mockStore.namespaces = { pub: 'https://localhost:8443/public/' }
+    const [_pad, additions] = getInitialisationStatements(new Date(0), mockStore)
+    expect(additions).toMatchSnapshot()
+  })
+
+  it('should include author information if available', async () => {
+    const mockStore = $rdf.graph()
+    mockStore.namespaces = { pub: 'https://localhost:8443/public/' }
+    const [_pad, additions] = getInitialisationStatements(
+      new Date(0),
+      mockStore,
+      $rdf.sym('https://mock-user')
+    )
+    expect(additions).toMatchSnapshot()
+  })
+})
+
+describe('getSetContentsStatements()', () => {
+  it('should properly set a notepad\'s contents', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+    const mockContents = `
+Here's some arbitrary
+multiline
+content
+    `
+    const [deletions, additions] = getSetContentsStatements(
+      mockContents,
+      new Date(0),
+      mockPad,
+      mockStore
+    )
+    expect(deletions).toEqual([])
+    expect(additions).toMatchSnapshot()
+  })
+
+  it('should include author information if available', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+    const mockContents = 'Arbitrary content'
+    const [deletions, additions] = getSetContentsStatements(
+      mockContents,
+      new Date(0),
+      mockPad,
+      mockStore,
+      $rdf.sym('https://mock-user')
+    )
+    expect(deletions).toEqual([])
+    expect(additions).toMatchSnapshot()
+  })
+
+  it('should clear previous content, if any', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+
+    const mockExistingLine = $rdf.sym('https://arbitrary-line')
+    mockStore.add(mockPad, ns.pad('next'), mockExistingLine, mockPad.doc())
+    mockStore.add(mockExistingLine, ns.pad('content'), 'Existing content', mockPad.doc())
+    mockStore.add(mockExistingLine, ns.dc('created'), new Date(0), mockPad.doc())
+
+    const mockContents = 'Arbitrary content'
+    const [deletions, _additions] = getSetContentsStatements(
+      mockContents,
+      new Date(0),
+      mockPad,
+      mockStore,
+      $rdf.sym('https://mock-user')
+    )
+    expect(deletions).toMatchSnapshot()
+  })
+})
+
+describe('getContents()', () => {
+  it('should be able to reconstruct a multiline file', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+
+    const mockFirstLine = $rdf.sym('https://arbitrary-line-1')
+    mockStore.add(mockPad, ns.pad('next'), mockFirstLine, mockPad.doc())
+    mockStore.add(mockFirstLine, ns.sioc('content'), 'First line', mockPad.doc())
+    mockStore.add(mockFirstLine, ns.dc('created'), new Date(0), mockPad.doc())
+    const mockSecondLine = $rdf.sym('https://arbitrary-line-2')
+    mockStore.add(mockFirstLine, ns.pad('next'), mockSecondLine, mockPad.doc())
+    mockStore.add(mockSecondLine, ns.sioc('content'), 'Second line', mockPad.doc())
+    mockStore.add(mockSecondLine, ns.dc('created'), new Date(0), mockPad.doc())
+    mockStore.add(mockSecondLine, ns.pad('next'), mockPad, mockPad.doc())
+
+    expect(getContents(mockStore, mockPad)).toBe(
+      // eslint-disable-next-line indent
+`First line
+Second line`
+    )
+  })
+})
+
+describe('getTitle()', () => {
+  it('should return a document\'s title', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+
+    mockStore.add(mockPad, ns.dc('title'), 'Some title', mockPad.doc())
+
+    expect(getTitle(mockStore, mockPad)).toBe('Some title')
+  })
+})
+
+describe('isPad()', () => {
+  it('should recognise when a subject is not a Pad', async () => {
+    const mockStore = $rdf.graph()
+    const mockNotAPad = $rdf.sym('https://mock-chat')
+    mockStore.add(mockNotAPad, ns.rdf('type'), ns.meeting('Chat'), mockNotAPad.doc())
+
+    expect(isPad(mockNotAPad, mockStore)).toBe(false)
+  })
+
+  it('should recognise when a subject is a Pad', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+    mockStore.add(mockPad, ns.rdf('type'), ns.pad('Notepad'), mockPad.doc())
+
+    expect(isPad(mockPad, mockStore)).toBe(true)
+  })
+})

--- a/scratchpad/data.test.ts
+++ b/scratchpad/data.test.ts
@@ -101,6 +101,22 @@ describe('getContents()', () => {
 Second line`
     )
   })
+
+  it('should ignore lines without contents', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = $rdf.sym('https://mock-pad')
+
+    const mockFirstLine = $rdf.sym('https://arbitrary-line-1')
+    mockStore.add(mockPad, ns.pad('next'), mockFirstLine, mockPad.doc())
+    mockStore.add(mockFirstLine, ns.sioc('content'), 'First line', mockPad.doc())
+    mockStore.add(mockFirstLine, ns.dc('created'), new Date(0), mockPad.doc())
+    const mockSecondLine = $rdf.sym('https://arbitrary-line-2')
+    mockStore.add(mockFirstLine, ns.pad('next'), mockSecondLine, mockPad.doc())
+    mockStore.add(mockSecondLine, ns.dc('created'), new Date(0), mockPad.doc())
+    mockStore.add(mockSecondLine, ns.pad('next'), mockPad, mockPad.doc())
+
+    expect(getContents(mockStore, mockPad)).toBe('First line')
+  })
 })
 
 describe('getTitle()', () => {

--- a/scratchpad/data.ts
+++ b/scratchpad/data.ts
@@ -81,7 +81,7 @@ export function getSetContentsStatements (
 
   const oldLines = store.statementsMatching(null as any, ns.pad('next'), null as any, pad.doc(), false)
     .map(statement => statement.object)
-    .filter(line => line !== pad)
+    .filter(line => line.value !== pad.value)
   const statementsPerOldLine = oldLines.map(oldLine => {
     return store.statementsMatching(oldLine, null as any, null as any, pad.doc(), false)
   })

--- a/scratchpad/data.ts
+++ b/scratchpad/data.ts
@@ -5,6 +5,7 @@ import { InitialisationFunction } from './types'
 
 const ns = vocab($rdf)
 
+/* istanbul ignore next [Side effects are contained to initialise(), so ignore just that for test coverage] */
 export const initialise: InitialisationFunction = async (store, user) => {
   const creationDate = new Date()
   const [pad, initialisationAdditions] = getInitialisationStatements(creationDate, store, user)

--- a/scratchpad/data.ts
+++ b/scratchpad/data.ts
@@ -12,7 +12,9 @@ export const initialise: InitialisationFunction = async (store, user) => {
   const [_setContentDeletions, setContentAdditions] = getSetContentsStatements('', creationDate, pad, store, user)
 
   const statementsToAdd = initialisationAdditions.concat(setContentAdditions)
-  await store.updater.put(pad, statementsToAdd, 'text/turtle', () => undefined)
+  if (store.updater) {
+    await store.updater.put(pad, statementsToAdd, 'text/turtle', () => undefined)
+  }
   return pad
 }
 

--- a/scratchpad/data.ts
+++ b/scratchpad/data.ts
@@ -1,0 +1,135 @@
+import '@babel/polyfill'
+import $rdf, { IndexedFormula, NamedNode, Statement, Node } from 'rdflib'
+import vocab from 'solid-namespace'
+import { InitialisationFunction } from './types'
+
+const ns = vocab($rdf)
+
+export const initialise: InitialisationFunction = async (store, user) => {
+  const creationDate = new Date()
+  const [pad, initialisationAdditions] = getInitialisationStatements(creationDate, store, user)
+  const [_setContentDeletions, setContentAdditions] = getSetContentsStatements('', creationDate, pad, store, user)
+
+  const statementsToAdd = initialisationAdditions.concat(setContentAdditions)
+  await store.updater.put(pad, statementsToAdd, 'text/turtle', () => undefined)
+  return pad
+}
+
+export function isPad (pad: NamedNode, store: IndexedFormula): boolean {
+  const [padStatement] = store.statementsMatching(
+    pad,
+    ns.rdf('type'),
+    ns.pad('Notepad'),
+    pad.doc(),
+    true
+  )
+
+  return !!padStatement
+}
+
+export function getInitialisationStatements (
+  creationDate: Date,
+  store: IndexedFormula,
+  user?: NamedNode
+): [NamedNode, Statement[]] {
+  const storeNamespaces = store.namespaces
+  const padName = creationDate.getTime()
+  const pad = store.sym(storeNamespaces.pub + padName + '/index.ttl#this')
+
+  const statementsToAdd = [
+    $rdf.st(pad, ns.rdf('type'), ns.pad('Notepad'), pad.doc()),
+    $rdf.st(pad, ns.dc('title'), `Scratchpad (${creationDate.toLocaleDateString()})`, pad.doc()),
+    $rdf.st(pad, ns.dc('created'), creationDate, pad.doc())
+  ]
+  if (user) {
+    statementsToAdd.push(
+      $rdf.st(pad, ns.dc('author'), user, pad.doc())
+    )
+  }
+
+  return [pad, statementsToAdd]
+}
+
+// Potential improvement: get current content, generate a diff
+export function getSetContentsStatements (
+  contents: string,
+  creationDate: Date,
+  pad: NamedNode,
+  store: IndexedFormula,
+  user?: NamedNode
+): [Statement[], Statement[]] {
+  const lines = contents.split('\n')
+  const statementsToAdd = lines.reduce(
+    (statementsToAdd, lineContents, lineNr) => {
+      const line = store.sym(pad.uri + `_line${lineNr}`)
+      const prevLine = (lineNr === 0) ? pad : statementsToAdd[statementsToAdd.length - 1].subject
+      statementsToAdd.push(
+        $rdf.st(prevLine, ns.pad('next'), line, pad.doc()),
+        $rdf.st(line, ns.sioc('content'), lineContents, pad.doc()),
+        $rdf.st(line, ns.dc('created'), creationDate, pad.doc())
+      )
+      if (user) {
+        statementsToAdd.push($rdf.st(line, ns.dc('author'), user, pad.doc()))
+      }
+
+      return statementsToAdd
+    },
+    [] as $rdf.Statement[]
+  )
+  const lastLine = statementsToAdd[statementsToAdd.length - 1].subject
+  statementsToAdd.push($rdf.st(lastLine, ns.pad('next'), pad, pad.doc()))
+
+  const oldLines = store.statementsMatching(null as any, ns.pad('next'), null as any, pad.doc(), false)
+    .map(statement => statement.object)
+    .filter(line => line !== pad)
+  const statementsPerOldLine = oldLines.map(oldLine => {
+    return store.statementsMatching(oldLine, null as any, null as any, pad.doc(), false)
+  })
+
+  const statementsToDelete = statementsPerOldLine.reduce(
+    (statementsToDelete, oldLineStatements) => {
+      statementsToDelete.push(...oldLineStatements)
+      return statementsToDelete
+    },
+    [] as $rdf.Statement[]
+  )
+  const [startingLink] = store.statementsMatching(pad, ns.pad('next'), null as any, pad.doc(), true)
+  if (startingLink) {
+    statementsToDelete.push(startingLink)
+  }
+
+  return [statementsToDelete, statementsToAdd]
+}
+
+export function getTitle (
+  store: IndexedFormula,
+  pad: NamedNode
+): string {
+  const [titleStatement] = store.statementsMatching(pad, ns.dc('title'), null, pad.doc(), true)
+  return titleStatement.object.value
+}
+
+export function getContents (
+  store: IndexedFormula,
+  pad: NamedNode
+): string {
+  const [firstLineStatement] = store.statementsMatching(pad, ns.pad('next'), null, pad.doc(), true)
+  let prevLine: Node = firstLineStatement.object
+  const lines = []
+  while (prevLine.value !== pad.value) {
+    const [currentLineStatement] = store.statementsMatching(prevLine, ns.pad('next'), null, pad.doc(), true)
+    const [lineContentStatement] = store.statementsMatching(
+      currentLineStatement.subject,
+      ns.sioc('content'),
+      null,
+      pad.doc(),
+      true
+    )
+    if (lineContentStatement) {
+      lines.push(lineContentStatement.object.value)
+    }
+    prevLine = currentLineStatement.object
+  }
+
+  return lines.join('\n')
+}

--- a/scratchpad/pane.ts
+++ b/scratchpad/pane.ts
@@ -1,9 +1,9 @@
 import { RevampPaneDefinition } from '../types'
 import { isPad, getTitle } from './data'
-import { view as scratchpadView } from './view';
+import { view as scratchpadView } from './view'
 
 export const pane: RevampPaneDefinition = {
   canHandle: (subject, store) => isPad(subject, store),
   label: (subject, store) => getTitle(store, subject),
-  attach: scratchpadView
+  view: scratchpadView
 }

--- a/scratchpad/pane.ts
+++ b/scratchpad/pane.ts
@@ -1,0 +1,15 @@
+import { RevampPaneDefinition } from '../types'
+import { isPad, getContents, getTitle } from './data'
+
+export const pane: RevampPaneDefinition = {
+  canHandle: (subject, store) => isPad(subject, store),
+  label: (subject, store) => getTitle(store, subject),
+  attach: (dom, subject, store) => {
+    const content = getContents(store, subject)
+    const lines = content.split('\n')
+    lines.forEach((line) => {
+      dom.appendChild(document.createTextNode(line))
+      dom.appendChild(document.createElement('br'))
+    })
+  }
+}

--- a/scratchpad/pane.ts
+++ b/scratchpad/pane.ts
@@ -1,15 +1,9 @@
 import { RevampPaneDefinition } from '../types'
-import { isPad, getContents, getTitle } from './data'
+import { isPad, getTitle } from './data'
+import { view as scratchpadView } from './view';
 
 export const pane: RevampPaneDefinition = {
   canHandle: (subject, store) => isPad(subject, store),
   label: (subject, store) => getTitle(store, subject),
-  attach: (dom, subject, store) => {
-    const content = getContents(store, subject)
-    const lines = content.split('\n')
-    lines.forEach((line) => {
-      dom.appendChild(document.createTextNode(line))
-      dom.appendChild(document.createElement('br'))
-    })
-  }
+  attach: scratchpadView
 }

--- a/scratchpad/paneWrapper.ts
+++ b/scratchpad/paneWrapper.ts
@@ -37,8 +37,12 @@ const paneWrapper: PaneDefinition = {
 
   render: function (subject, _dom) {
     const container = document.createElement('div')
-    const user = UI.authn.currentUser()
-    pane.attach(container, subject, UI.store, user)
+    pane.view({
+      container: container,
+      subject: subject,
+      store: UI.store,
+      user: UI.authn.currentUser()
+    })
     return container
   }
 }

--- a/scratchpad/paneWrapper.ts
+++ b/scratchpad/paneWrapper.ts
@@ -1,0 +1,45 @@
+import { PaneDefinition } from '../types'
+import { pane } from './pane'
+import { initialise } from './data'
+import { Namespaces } from 'solid-namespace'
+import UI from 'solid-ui'
+import { IndexedFormula } from 'rdflib'
+
+const store: IndexedFormula = UI.store
+const ns: Namespaces = UI.ns
+
+const paneWrapper: PaneDefinition = {
+  // TODO: Replace
+  icon: UI.icons.iconBase + 'noun_79217.svg',
+
+  name: 'scratchpad',
+
+  label: function (subject) {
+    if (!pane.canHandle(subject, store)) {
+      return null
+    }
+
+    return pane.label(subject, store)
+  },
+
+  mintClass: ns.pad('Notepad'),
+
+  mintNew: async function (newPaneOptions) {
+    var kb = UI.store
+
+    const createdPad = await initialise(kb, newPaneOptions.me)
+
+    newPaneOptions.newInstance = createdPad
+    newPaneOptions.newBase = createdPad.doc().value.replace(/\/index.ttl$/, '/')
+
+    return newPaneOptions
+  },
+
+  render: function (subject, _dom) {
+    const container = document.createElement('div')
+    pane.attach(container, subject, UI.store)
+    return container
+  }
+}
+
+export default paneWrapper

--- a/scratchpad/paneWrapper.ts
+++ b/scratchpad/paneWrapper.ts
@@ -3,7 +3,7 @@ import { pane } from './pane'
 import { initialise } from './data'
 import { Namespaces } from 'solid-namespace'
 import UI from 'solid-ui'
-import { IndexedFormula } from 'rdflib'
+import { IndexedFormula, NamedNode } from 'rdflib'
 
 const store: IndexedFormula = UI.store
 const ns: Namespaces = UI.ns
@@ -41,10 +41,16 @@ const paneWrapper: PaneDefinition = {
       container: container,
       subject: subject,
       store: UI.store,
+      visitNode: visitNode,
       user: UI.authn.currentUser()
     })
     return container
   }
+}
+
+function visitNode (node: NamedNode) {
+  const outliner = (window as any).panes.getOutliner(document)
+  outliner.GotoSubject(node, true, undefined, true, undefined)
 }
 
 export default paneWrapper

--- a/scratchpad/paneWrapper.ts
+++ b/scratchpad/paneWrapper.ts
@@ -37,7 +37,8 @@ const paneWrapper: PaneDefinition = {
 
   render: function (subject, _dom) {
     const container = document.createElement('div')
-    pane.attach(container, subject, UI.store)
+    const user = UI.authn.currentUser()
+    pane.attach(container, subject, UI.store, user)
     return container
   }
 }

--- a/scratchpad/types.ts
+++ b/scratchpad/types.ts
@@ -1,0 +1,3 @@
+import { IndexedFormula, NamedNode } from 'rdflib'
+
+export type InitialisationFunction = (store: IndexedFormula, user?: NamedNode) => Promise<NamedNode>;

--- a/scratchpad/view.test.ts
+++ b/scratchpad/view.test.ts
@@ -1,0 +1,70 @@
+/* eslint-env jest */
+import $rdf from 'rdflib'
+import vocab from 'solid-namespace'
+import { view } from './view'
+
+const ns = vocab($rdf)
+
+function addMockPad (mockStore: $rdf.IndexedFormula): $rdf.NamedNode {
+  const mockPad = $rdf.sym('https://mock-pad')
+  const mockFirstLine = $rdf.sym('https://arbitrary-line-1')
+  mockStore.add(mockPad, ns.pad('next'), mockFirstLine, mockPad.doc())
+  mockStore.add(mockFirstLine, ns.sioc('content'), 'First line', mockPad.doc())
+  mockStore.add(mockFirstLine, ns.dc('created'), new Date(0), mockPad.doc())
+  const mockSecondLine = $rdf.sym('https://arbitrary-line-2')
+  mockStore.add(mockFirstLine, ns.pad('next'), mockSecondLine, mockPad.doc())
+  mockStore.add(mockSecondLine, ns.sioc('content'), 'Second line', mockPad.doc())
+  mockStore.add(mockSecondLine, ns.dc('created'), new Date(0), mockPad.doc())
+  mockStore.add(mockSecondLine, ns.pad('next'), mockPad, mockPad.doc())
+
+  return mockPad
+}
+
+describe('View mode', () => {
+  it('should not show an edit button when the user is not logged in', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = addMockPad(mockStore)
+
+    const container = document.createElement('div')
+
+    view({
+      container: container,
+      subject: mockPad,
+      store: mockStore
+    })
+    const button = container.querySelector('button')
+    expect(button).toBeNull()
+  })
+
+  it('should show an edit button when the user is logged in', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = addMockPad(mockStore)
+    const mockUser = $rdf.sym('https://mock-user')
+
+    const container = document.createElement('div')
+
+    view({
+      container: container,
+      subject: mockPad,
+      store: mockStore,
+      user: mockUser
+    })
+    const button = container.querySelector('button')
+    expect(button).toBeDefined()
+    expect(button!.textContent).toBe('Edit')
+  })
+
+  it('should properly render the pad\'s contents', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = addMockPad(mockStore)
+
+    const container = document.createElement('div')
+
+    view({
+      container: container,
+      subject: mockPad,
+      store: mockStore
+    })
+    expect(container.outerHTML).toMatchSnapshot()
+  })
+})

--- a/scratchpad/view.test.ts
+++ b/scratchpad/view.test.ts
@@ -30,7 +30,8 @@ describe('View mode', () => {
     view({
       container: container,
       subject: mockPad,
-      store: mockStore
+      store: mockStore,
+      visitNode: jest.fn()
     })
     const button = container.querySelector('button')
     expect(button).toBeNull()
@@ -47,7 +48,8 @@ describe('View mode', () => {
       container: container,
       subject: mockPad,
       store: mockStore,
-      user: mockUser
+      user: mockUser,
+      visitNode: jest.fn()
     })
     const button = container.querySelector('button')
     expect(button).toBeDefined()
@@ -63,7 +65,8 @@ describe('View mode', () => {
     view({
       container: container,
       subject: mockPad,
-      store: mockStore
+      store: mockStore,
+      visitNode: jest.fn()
     })
     expect(container.outerHTML).toMatchSnapshot()
   })
@@ -81,6 +84,7 @@ describe('Edit mode', () => {
       container: container,
       subject: mockPad,
       store: mockStore,
+      visitNode: jest.fn(),
       user: mockUser
     })
     const button = container.querySelector('button')

--- a/scratchpad/view.test.ts
+++ b/scratchpad/view.test.ts
@@ -68,3 +68,25 @@ describe('View mode', () => {
     expect(container.outerHTML).toMatchSnapshot()
   })
 })
+
+describe('Edit mode', () => {
+  it('should switch to edit mode when clicking the edit button', async () => {
+    const mockStore = $rdf.graph()
+    const mockPad = addMockPad(mockStore)
+    const mockUser = $rdf.sym('https://mock-user')
+
+    const container = document.createElement('div')
+
+    view({
+      container: container,
+      subject: mockPad,
+      store: mockStore,
+      user: mockUser
+    })
+    const button = container.querySelector('button')
+    button!.dispatchEvent(new Event('click'))
+
+    const textarea = container.querySelector('textarea')
+    expect(textarea).toBeDefined()
+  })
+})

--- a/scratchpad/view.ts
+++ b/scratchpad/view.ts
@@ -1,17 +1,12 @@
-import { NamedNode, IndexedFormula } from 'rdflib';
-import { getContents, getSetContentsStatements } from './data';
+import { getContents, getSetContentsStatements } from './data'
+import { ViewParams } from '../types'
 
-export function view(
-  container: HTMLElement,
-  subject: NamedNode,
-  store: IndexedFormula,
-  user?: NamedNode
-) {
+export function view ({ container, subject, store, user }: ViewParams) {
   toViewMode()
 
-  function toViewMode() {
+  function toViewMode () {
     const content = getContents(store, subject)
-    container.innerHTML = '';
+    container.innerHTML = ''
 
     const lines = content.split('\n')
     lines.forEach((line) => {
@@ -30,13 +25,13 @@ export function view(
     }
   }
 
-  function toEditMode() {
+  function toEditMode () {
     if (!user) {
       return
     }
 
     const content = getContents(store, subject)
-    container.innerHTML = '<form><textarea></textarea><button type="submit">Save</button></form>';
+    container.innerHTML = '<form><textarea></textarea><button type="submit">Save</button></form>'
 
     const textArea = container.getElementsByTagName('textarea')[0]
     textArea.textContent = content

--- a/scratchpad/view.ts
+++ b/scratchpad/view.ts
@@ -1,7 +1,11 @@
-import { getContents, getSetContentsStatements } from './data'
+import vocab from 'solid-namespace'
+import $rdf from 'rdflib'
+import { getContents, getSetContentsStatements, getLatestAuthor } from './data'
 import { ViewParams } from '../types'
 
-export function view ({ container, subject, store, user }: ViewParams) {
+const ns = vocab($rdf)
+
+export function view ({ container, subject, store, visitNode, user }: ViewParams) {
   toViewMode()
 
   function toViewMode () {
@@ -14,6 +18,8 @@ export function view ({ container, subject, store, user }: ViewParams) {
       container.appendChild(document.createElement('br'))
     })
 
+    container.appendChild(document.createElement('hr'))
+
     if (user) {
       const editButton = document.createElement('button')
       editButton.textContent = 'Edit'
@@ -22,6 +28,33 @@ export function view ({ container, subject, store, user }: ViewParams) {
         toEditMode()
       })
       container.appendChild(editButton)
+      container.appendChild(document.createElement('br'))
+    }
+
+    const authorContainer = document.createElement('small')
+    container.appendChild(authorContainer)
+    showLatestAuthor(authorContainer)
+  }
+
+  /* istanbul ignore next [This function depends on a side effect (fetch), so skip it for testing for now:] */
+  async function showLatestAuthor (authorContainer: HTMLElement) {
+    const latestAuthor = getLatestAuthor(store, subject)
+    if (latestAuthor) {
+      const fetcher = $rdf.fetcher(store, {})
+      await fetcher.load(latestAuthor.uri)
+      const [nameStatement] = store.statementsMatching(latestAuthor, ns.vcard('fn'), null, null, true)
+
+      authorContainer.appendChild(document.createTextNode('Latest author: '))
+      const authorLink = document.createElement('a')
+      authorLink.href = latestAuthor.uri
+      const name = (nameStatement) ? nameStatement.object.value : latestAuthor.uri
+      authorLink.textContent = name
+      authorLink.title = `View the profile of ${name}`
+      authorLink.addEventListener('click', (event) => {
+        event.preventDefault()
+        visitNode(latestAuthor)
+      })
+      authorContainer.appendChild(authorLink)
     }
   }
 

--- a/scratchpad/view.ts
+++ b/scratchpad/view.ts
@@ -1,0 +1,53 @@
+import { NamedNode, IndexedFormula } from 'rdflib';
+import { getContents, getSetContentsStatements } from './data';
+
+export function view(
+  container: HTMLElement,
+  subject: NamedNode,
+  store: IndexedFormula,
+  user?: NamedNode
+) {
+  toViewMode()
+
+  function toViewMode() {
+    const content = getContents(store, subject)
+    container.innerHTML = '';
+
+    const lines = content.split('\n')
+    lines.forEach((line) => {
+      container.appendChild(document.createTextNode(line))
+      container.appendChild(document.createElement('br'))
+    })
+
+    if (user) {
+      const editButton = document.createElement('button')
+      editButton.textContent = 'Edit'
+      editButton.addEventListener('click', (event) => {
+        event.preventDefault()
+        toEditMode()
+      })
+      container.appendChild(editButton)
+    }
+  }
+
+  function toEditMode() {
+    if (!user) {
+      return
+    }
+
+    const content = getContents(store, subject)
+    container.innerHTML = '<form><textarea></textarea><button type="submit">Save</button></form>';
+
+    const textArea = container.getElementsByTagName('textarea')[0]
+    textArea.textContent = content
+
+    const form = container.getElementsByTagName('form')[0]
+    form.addEventListener('submit', (event) => {
+      event.preventDefault()
+
+      const creationDate = new Date()
+      const [setContentDeletions, setContentAdditions] = getSetContentsStatements(textArea.value, creationDate, subject, store, user)
+      store.updater.update(setContentDeletions, setContentAdditions, toViewMode)
+    })
+  }
+}

--- a/scratchpad/view.ts
+++ b/scratchpad/view.ts
@@ -26,6 +26,7 @@ export function view ({ container, subject, store, user }: ViewParams) {
   }
 
   function toEditMode () {
+    /* istanbul ignore if [This should not be able to happen, but since the view is not stateless, we cannot verify this in unit tests.] */
     if (!user) {
       return
     }
@@ -37,6 +38,7 @@ export function view ({ container, subject, store, user }: ViewParams) {
     textArea.textContent = content
 
     const form = container.getElementsByTagName('form')[0]
+    /* istanbul ignore next [Side effects get executed here, so do not run them in unit tests:] */
     form.addEventListener('submit', (event) => {
       event.preventDefault()
 

--- a/scratchpad/view.ts
+++ b/scratchpad/view.ts
@@ -77,7 +77,9 @@ export function view ({ container, subject, store, visitNode, user }: ViewParams
 
       const creationDate = new Date()
       const [setContentDeletions, setContentAdditions] = getSetContentsStatements(textArea.value, creationDate, subject, store, user)
-      store.updater.update(setContentDeletions, setContentAdditions, toViewMode)
+      if (store.updater) {
+        store.updater.update(setContentDeletions, setContentAdditions, toViewMode)
+      }
     })
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -30,6 +30,7 @@ export interface ViewParams {
   container: HTMLElement;
   subject: NamedNode;
   store: IndexedFormula;
+  visitNode: (node: NamedNode) => void;
   user?: NamedNode;
 };
 

--- a/types.ts
+++ b/types.ts
@@ -26,9 +26,16 @@ interface NewPaneOptions {
   refreshTarget: HTMLTableElement;
 }
 
+export interface ViewParams {
+  container: HTMLElement;
+  subject: NamedNode;
+  store: IndexedFormula;
+  user?: NamedNode;
+};
+
 export interface RevampPaneDefinition {
   canHandle: (subject: NamedNode, store: IndexedFormula) => boolean;
-  attach: (container: HTMLElement, subject: NamedNode, store: IndexedFormula, user?: NamedNode) => void;
+  view: (params: ViewParams) => void;
   label: (subject: NamedNode, store: IndexedFormula) => string | null;
 };
 interface NewPaneOptions {

--- a/types.ts
+++ b/types.ts
@@ -28,7 +28,7 @@ interface NewPaneOptions {
 
 export interface RevampPaneDefinition {
   canHandle: (subject: NamedNode, store: IndexedFormula) => boolean;
-  attach: (container: HTMLElement, subject: NamedNode, store: IndexedFormula) => void;
+  attach: (container: HTMLElement, subject: NamedNode, store: IndexedFormula, user?: NamedNode) => void;
   label: (subject: NamedNode, store: IndexedFormula) => string | null;
 };
 interface NewPaneOptions {

--- a/types.ts
+++ b/types.ts
@@ -9,7 +9,27 @@ export interface PaneDefinition {
   shouldGetFocus?: (subject: NamedNode) => boolean;
   requireQueryButton?: boolean;
   mintClass?: NamedNode;
-  mintNew?: (options: NewPaneOptions, store: IndexedFormula) => Promise<NewPaneOptions & { newInstance: NamedNode }>;
+  mintNew?: (options: NewPaneOptions) => Promise<NewPaneOptions & { newInstance: NamedNode }>;
+};
+interface NewPaneOptions {
+  appPathSegment: string;
+  div: HTMLDivElement;
+  dom: HTMLDocument;
+  folder: NamedNode;
+  iconEle: HTMLImageElement;
+  me?: NamedNode;
+  newBase: string;
+  newInstance: NamedNode;
+  noIndexHTML: boolean;
+  noun: string;
+  pane: PaneDefinition;
+  refreshTarget: HTMLTableElement;
+}
+
+export interface RevampPaneDefinition {
+  canHandle: (subject: NamedNode, store: IndexedFormula) => boolean;
+  attach: (container: HTMLElement, subject: NamedNode, store: IndexedFormula) => void;
+  label: (subject: NamedNode, store: IndexedFormula) => string | null;
 };
 interface NewPaneOptions {
   appPathSegment: string;

--- a/types.ts
+++ b/types.ts
@@ -1,11 +1,27 @@
-import { Node } from 'rdflib'
+import { NamedNode, IndexedFormula } from 'rdflib'
 
 // Note: there might be a more appropriate project to hold this definition:
 export interface PaneDefinition {
   icon: string;
   name: string;
-  label: (subject: Node) => string | null;
-  render: (subject: Node, dom: HTMLDocument, options?: unknown) => HTMLElement;
-  shouldGetFocus?: (subject: Node) => boolean;
+  label: (subject: NamedNode) => string | null;
+  render: (subject: NamedNode, dom: HTMLDocument, options?: unknown) => HTMLElement;
+  shouldGetFocus?: (subject: NamedNode) => boolean;
   requireQueryButton?: boolean;
+  mintClass?: NamedNode;
+  mintNew?: (options: NewPaneOptions, store: IndexedFormula) => Promise<NewPaneOptions & { newInstance: NamedNode }>;
 };
+interface NewPaneOptions {
+  appPathSegment: string;
+  div: HTMLDivElement;
+  dom: HTMLDocument;
+  folder: NamedNode;
+  iconEle: HTMLImageElement;
+  me?: NamedNode;
+  newBase: string;
+  newInstance: NamedNode;
+  noIndexHTML: boolean;
+  noun: string;
+  pane: PaneDefinition;
+  refreshTarget: HTMLTableElement;
+}

--- a/typings/rdflib/index.d.ts
+++ b/typings/rdflib/index.d.ts
@@ -1,0 +1,1261 @@
+declare module 'rdflib' {
+// Type definitions for rdflib 0.20
+// Project: http://github.com/linkeddata/rdflib.js
+// Definitions by: Cénotélie <https://github.com/cenotelie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+// Acknowledgements: This work has been financed by Logilab SA, FRANCE, logilab.fr
+
+/**
+ * Class orders
+ */
+export const ClassOrder: {
+  [id: string]: number;
+};
+/**
+* A type for values that serves as inputs
+*/
+export type ValueType = Node | Date | string | number | boolean | undefined;
+/**
+* The superclass of all RDF Statement objects, that is NamedNode, Literal, BlankNode, etc.
+*/
+export class Node {
+  /**
+   * The type of node
+   */
+  termType: string;
+  /**
+   * Whether this node is a variable
+   */
+  isVar: boolean;
+  /**
+   * The class order for this node
+   */
+  classOrder: number;
+  /**
+   * The nod's value
+   */
+  value: string;
+  /**
+   * Gets the substituted node for this one, according to the specified bindings
+   * @param bindings Bindings of identifiers to nodes
+   */
+  substitute(bindings: { [id: string]: Node }): Node;
+  /**
+   * Compares this node with another
+   * @param term The other node
+   */
+  compareTerm(term: Node): number;
+  /**
+   * Gets whether the two nodes are equal
+   * @param other The other node
+   */
+  equals(other: Node): boolean;
+  /**
+   * Gets a hash for this node
+   */
+  hashString(): string;
+  /**
+   * Gets whether this node is the same as the other one
+   * @param other Another node
+   */
+  sameTerm(other: Node): boolean;
+  /**
+   * Gets the canonical string representation of this node
+   */
+  toCanonical(): string;
+  /**
+   * Gets the n-triples string representation of this node
+   */
+  toNT(): string;
+  /**
+   * Gets the string representation of this node
+   */
+  toString(): string;
+  /**
+   * Gets a node for the specifed input
+   * @param value An input value
+   */
+  static fromValue(value: ValueType): Node | ValueType;
+  /**
+   * Gets the javascript object equivalent to a node
+   * @param term The RDF node
+   */
+  static toJS(term: Node): any;
+}
+/**
+* An empty node
+*/
+export class Empty extends Node {
+  constructor();
+  static termType: string;
+}
+/**
+* A collection of other RDF nodes
+*/
+export class Collection extends Node {
+  /**
+   * The identifier for this collection
+   */
+  id: string;
+  /**
+   * The nodes in this collection
+   */
+  elements: Node[];
+  /**
+   * Whether this collection is closed
+   */
+  closed: boolean;
+  /**
+   * Initializes this collection
+   * @param initial The initial elements
+   */
+  constructor(initial: ReadonlyArray<ValueType>);
+  /**
+   * Appends an element to this collection
+   * @param element The new element
+   */
+  append(element: Node): number;
+  /**
+   * Closes this collection
+   */
+  close(): boolean;
+  /**
+   * Removes the first element from the collection (and return it)
+   */
+  shift(): Node;
+  /**
+   * Preprends the specified element to the colelction's front
+   * @param element The element to preprend
+   */
+  unshift(element: Node): number;
+  static termType: string;
+}
+/**
+* An RDF blank node
+*/
+export class BlankNode extends Node {
+  /**
+   * The identifier for the blank node
+   */
+  id: string;
+  /**
+   * Whether this is a blank node
+   */
+  isBlank: boolean;
+  /**
+   * Initializes this node
+   * @param id The identifier for the blank node
+   */
+  constructor(id: string);
+  /**
+   * Gets a copy of this blank node in the specified formula
+   * @param formula The formula
+   */
+  copy(formula: Formula): BlankNode;
+  /**
+   * The next unique identifier for blank nodes
+   */
+  static nextId: number;
+  static termType: string;
+  static NTAnonymousNodePrefix: string;
+}
+/**
+* A named (IRI) RDF node
+*/
+export class NamedNode extends Node {
+  /**
+   * The URI for this node
+   */
+  uri: string;
+  /**
+   * Initializes this node
+   * @param iri The IRI for this node
+   */
+  constructor(iri: NamedNode | string);
+  /**
+   * Returns an RDF node for the containing directory, ending in slash.
+   */
+  dir(): NamedNode;
+  /**
+   * Returns an named node for the whole web site, ending in slash.
+   * Contrast with the "origin" which does NOT have a trailing slash
+   */
+  site(): NamedNode;
+  /**
+   * Gets the named node for the document
+   */
+  doc(): NamedNode;
+  static termType: string;
+  /**
+   * Gets a named node from the specified input value
+   * @param value An input value
+   */
+  static fromValue(value: ValueType): NamedNode | ValueType;
+}
+/**
+* A RDF literal node
+*/
+export class Literal extends Node {
+  /**
+   * The language for the literal
+   */
+  lang: string;
+  /**
+   * The language for the literal
+   */
+  language: string;
+  /**
+   * The literal's datatype as a named node
+   */
+  datatype: NamedNode;
+  /**
+   * Initializes this literal
+   * @param value The literal's lexical value
+   * @param language The language for the literal
+   * @param datatype The literal's datatype as a named node
+   */
+  constructor(value: string, language: string, datatype: NamedNode);
+  /**
+   * Gets a copy of this literal
+   */
+  copy(): Literal;
+  static termType: string;
+  /**
+   * Builds a literal node from a boolean value
+   * @param value The value
+   */
+  static fromBoolean(value: boolean): Literal;
+  /**
+   * Builds a literal node from a date value
+   * @param value The value
+   */
+  static fromDate(value: Date): Literal;
+  /**
+   * Builds a literal node from a number value
+   * @param value The value
+   */
+  static fromNumber(value: number): Literal;
+  /**
+   * Builds a literal node from an input value
+   * @param value The input value
+   */
+  static fromValue(value: ValueType): Literal | ValueType;
+}
+/**
+* Variables are placeholders used in patterns to be matched.
+* In cwm they are symbols which are the formula's list of quantified variables.
+* In sparql they are not visibly URIs.  Here we compromise, by having
+* a common special base URI for variables. Their names are uris,
+* but the ? notation has an implicit base uri of 'varid:'
+*/
+export class Variable extends Node {
+  /**
+   * The base string for a variable's name
+   */
+  base: string;
+  /**
+   * The unique identifier of this variable
+   */
+  uri: string;
+  /**
+   * Initializes this variable
+   * @param name The variable's name
+   */
+  constructor(name: string);
+  static termType: string;
+}
+/**
+* The RDF default graph
+*/
+export class DefaultGraph extends Node {
+  /**
+   * Initializes this graph
+   */
+  constructor();
+}
+export namespace uri {
+  /**
+   * Gets the document part of an URI
+   * @param uri The URI
+   */
+  function docpart(uri: string): string;
+  /**
+   * Gets the document part of an URI as a named node
+   * @param x The URI
+   */
+  function document(x: string): NamedNode;
+  /**
+   * Gets the hostname in an URI
+   * @param u The URI
+   */
+  function hostpart(u: string): string;
+  /**
+   * Joins an URI with a base
+   * @param given The relative part
+   * @param base The base URI
+   */
+  function join(given: string, base: string): string;
+  /**
+   * Gets the protocol part of an URI
+   * @param uri The URI
+   */
+  function protocol(uri: string): string;
+  /**
+   * Gets a relative uri
+   * @param base The base URI
+   * @param uri The absolute URI
+   */
+  function refTo(base: string, uri: string): string;
+}
+export namespace log {
+  /**
+   * Logs a debug event
+   * @param x The event
+   */
+  function debug(x: any): void;
+  /**
+   * Logs a warning event
+   * @param x The event
+   */
+  function warn(x: any): void;
+  /**
+   * Logs an information event
+   * @param x The event
+   */
+  function info(x: any): void;
+  /**
+   * Logs an error event
+   * @param x The event
+   */
+  function error(x: any): void;
+  /**
+   * Logs a success event
+   * @param x The event
+   */
+  function success(x: any): void;
+  /**
+   * Logs a message event
+   * @param x The event
+   */
+  function msg(x: any): void;
+}
+/**
+* An RDF statement (subject, predicate, object)
+*/
+export class Statement {
+  /**
+   * The statement's subject
+   */
+  subject: Node;
+  /**
+   * The statement's predicate
+   */
+  predicate: Node;
+  /**
+   * The statement's object
+   */
+  object: Node;
+  /**
+   * The origin of this statement
+   */
+  why: ValueType;
+  /**
+   * The graph the contains this statement
+   */
+  graph: ValueType;
+  /**
+   * Initializes this statement
+   * @param subject The statement's subject
+   * @param predicate The statement's predicate
+   * @param object The statement's object
+   * @param graph The graph the contains this statement
+   */
+  constructor(
+      subject: ValueType,
+      predicate: ValueType,
+      object: ValueType,
+      graph: ValueType
+  );
+  /**
+   * Gets whether two statements are the same
+   * @param other The other statement
+   */
+  equals(other: Statement): boolean;
+  /**
+   * Gets this statement with the bindings substituted
+   * @param bindings The bindings
+   */
+  substitute(bindings: { [id: string]: Node }): Statement;
+  /**
+   * Gets the canonical string representation of this statement
+   */
+  toCanonical(): string;
+  /**
+   * Gets the n-triples string representation of this statement
+   */
+  toNT(): string;
+  /**
+   * Gets the string representation of this statement
+   */
+  toString(): string;
+}
+export namespace convert {
+  /**
+   * Converts an n3 string to JSON
+   * @param n3String The n3 string
+   * @param jsonCallback Callback when the operation terminated
+   */
+  function convertToJson(
+      n3String: string,
+      jsonCallback: (err: string, jsonString: string) => void
+  ): void;
+  /**
+   * Converts an n3 string to n-quads
+   * @param n3String The n3 string
+   * @param nquadCallback Callback when the operation terminated
+   */
+  function convertToNQuads(
+      n3String: string,
+      nquadCallback: (err: string, nquadString: string) => void
+  ): void;
+}
+/**
+* A formula, or store of RDF statements
+*/
+export class Formula extends Node {
+  /**
+   * The stored statements
+   */
+  statements: Statement[];
+  /**
+   * Initializes this formula
+   * @param statements The initial statements in this formulat
+   * @param constraints The additional constraints
+   * @param initBindings The initial bindings
+   * @param optional
+   */
+  constructor(
+      statements: ReadonlyArray<Statement>,
+      constraints: ReadonlyArray<any>,
+      initBindings: {
+          [id: string]: Node;
+      },
+      optional: ReadonlyArray<any>
+  );
+  /**
+   * Adds a statement to this formula
+   * @param s The subject
+   * @param p The predicate
+   * @param o The object
+   * @param g The graph that contains the statement
+   */
+  add(s: ValueType, p: ValueType, o: ValueType, g: ValueType): number;
+  /**
+   * Adds a statement to this formula
+   * @param st The statement to add
+   */
+  addStatement(st: Statement): number;
+  /**
+   * Gets a node that matches the specified pattern
+   * @param s The subject
+   * @param p The predicate
+   * @param o The object
+   * @param g The graph that contains the statement
+   */
+  any(s: ValueType, p: ValueType, o: ValueType, g: ValueType): Node;
+  /**
+   * Gets a blank node
+   * @param id The node's identifier
+   */
+  bnode(id: string): BlankNode;
+  /**
+   * Finds the types in the list which have no *stored* subtypes
+   * These are a set of classes which provide by themselves complete
+   * information -- the other classes are redundant for those who
+   * know the class DAG.
+   * @param types A map of the types
+   */
+  bottomTypeURIs(types: {
+      [id: string]: string | NamedNode;
+  }): {
+      [id: string]: string | NamedNode;
+  };
+  /**
+   * Gets a new collection
+   */
+  collection(): Collection;
+  /**
+   * Gets each node that matches the specified pattern
+   * @param s The subject
+   * @param p The predicate
+   * @param o The object
+   * @param g The graph that contains the statement
+   */
+  each(s: ValueType, p: ValueType, o: ValueType, g: ValueType): Node[];
+  /**
+   * Gets whether this formula is equals to the other one
+   * @param other The other formula
+   */
+  equals(other: Formula): boolean;
+  /**
+   * For thisClass or any subclass, anything which has it is its type
+   * or is the object of something which has the type as its range, or subject
+   * of something which has the type as its domain
+   * We don't bother doing subproperty (yet?)as it doesn't seeem to be used
+   * much.
+   * Get all the Classes of which we can RDFS-infer the subject is a member
+   * @param thisClass A named node
+   */
+  findMembersNT(
+      thisClass: Node
+  ): {
+      [uri: string]: Statement;
+  };
+  /**
+   * For thisClass or any subclass, anything which has it is its type
+   * or is the object of something which has the type as its range, or subject
+   * of something which has the type as its domain
+   * We don't bother doing subproperty (yet?)as it doesn't seeem to be used
+   * much.
+   * Get all the Classes of which we can RDFS-infer the subject is a member
+   * @param subject A named node
+   */
+  findMemberURIs(
+      subject: Node
+  ): {
+      [uri: string]: Statement;
+  };
+  /**
+   * Get all the Classes of which we can RDFS-infer the subject is a superclass
+   * Returns a hash table where key is NT of type and value is statement why we
+   * think so.
+   * Does NOT return terms, returns URI strings.
+   * We use NT representations in this version because they handle blank nodes.
+   * @param subject A subject node
+   */
+  findSubClassesNT(
+      subject: Node
+  ): {
+      [uri: string]: boolean;
+  };
+  /**
+   * Get all the Classes of which we can RDFS-infer the subject is a subclass
+   * Returns a hash table where key is NT of type and value is statement why we
+   * think so.
+   * Does NOT return terms, returns URI strings.
+   * We use NT representations in this version because they handle blank nodes.
+   * @param subject A subject node
+   */
+  findSuperClassesNT(
+      subject: Node
+  ): {
+      [uri: string]: boolean;
+  };
+  /**
+   * Get all the Classes of which we can RDFS-infer the subject is a member
+   * todo: This will loop is there is a class subclass loop (Sublass loops are
+   * not illegal)
+   * Returns a hash table where key is NT of type and value is statement why we
+   * think so.
+   * Does NOT return terms, returns URI strings.
+   * We use NT representations in this version because they handle blank nodes.
+   * @param subject A subject node
+   */
+  findTypesNT(
+      subject: Node
+  ): {
+      [uri: string]: boolean;
+  };
+  /**
+   * Get all the Classes of which we can RDFS-infer the subject is a member
+   * todo: This will loop is there is a class subclass loop (Sublass loops are
+   * not illegal)
+   * Returns a hash table where key is NT of type and value is statement why we
+   * think so.
+   * Does NOT return terms, returns URI strings.
+   * We use NT representations in this version because they handle blank nodes.
+   * @param subject A subject node
+   */
+  findTypeURIs(
+      subject: Node
+  ): {
+      [uri: string]: boolean;
+  };
+  /**
+   * Trace the statements which connect directly, or through bnodes
+   * Returns an array of statements
+   * doc param may be null to search all documents in store
+   * @param subject A subject node
+   * @param doc A document (the graph that contains statements)
+   * @param excludePredicateURIs The predicate URIs to exclude
+   */
+  connectedStatements(
+      subject: Node,
+      doc: ValueType,
+      excludePredicateURIs: ReadonlyArray<string>
+  ): Statement[];
+  /**
+   * Creates a new empty formula
+   */
+  formula(): Formula;
+  /**
+   * Creates a new empty indexed formulat
+   * @param features The list of features
+   */
+  formula(features: ReadonlyArray<string>): IndexedFormula;
+  /**
+   * Transforms an NTriples string format into a Node.
+   * The bnode bit should not be used on program-external values; designed
+   * for internal work such as storing a bnode id in an HTML attribute.
+   * This will only parse the strings generated by the vaious toNT() methods.
+   * @param str A string representation
+   */
+  fromNT(str: string): Node;
+  /**
+   * Gets whether this formula holds the specified statement
+   * @param s A subject
+   * @param p A predicate
+   * @param o An object
+   * @param g A containing graph
+   */
+  holds(s: ValueType, p: ValueType, o: ValueType, g: ValueType): boolean;
+  /**
+   * Gets whether this formula holds the specified statement
+   * @param s A statement
+   */
+  holds(s: Statement | ReadonlyArray<Statement>): boolean;
+  /**
+   * Gets whether this formula holds the specified statement
+   * @param st A statement
+   */
+  holdsStatement(st: Statement): boolean;
+  /**
+   * Gets a collection from a list of values
+   * @param values The values
+   */
+  list(values: Iterable<ValueType>): Collection;
+  /**
+   * Gets a literal node
+   * @param val The literal's lexical value
+   * @param lang The language
+   * @param dt The datatype as a named node
+   */
+  literal(val: string, lang: string, dt: NamedNode): Literal;
+  /**
+   * Transform a collection of NTriple URIs into their URI strings
+   * @param t some iterable colletion of NTriple URI strings
+   * @return a collection of the URIs as strings
+   */
+  NTtoURI(t: {
+      [uri: string]: any;
+  }): {
+      [uri: string]: any;
+  };
+  /**
+   * Serializes this formula
+   * @param base The base string
+   * @param contentType The content type of the syntax to use
+   * @param provenance The provenance URI
+   */
+  serialize(base: string, contentType: string, provenance: string): string;
+  /**
+   * Gets a new formula with the substituting bindings applied
+   * @param bindings The bindings to substitute
+   */
+  substitute(bindings: { [id: string]: Node }): Formula;
+  /**
+   * Gets an named node for an URI
+   * @param uri The URI
+   */
+  sym(uri: string | NamedNode): NamedNode;
+  /**
+   * Gets the node matching the specified pattern
+   * @param s The subject
+   * @param p The predicate
+   * @param o The object
+   * @param g The graph that contains the statement
+   */
+  the(s: ValueType, p: ValueType, o: ValueType, g: ValueType): Node;
+  /**
+   * RDFS Inference
+   * These are hand-written implementations of a backward-chaining reasoner
+   * over the RDFS axioms.
+   * @param seeds A hash of NTs of classes to start with
+   * @param predicate The property to trace though
+   * @param inverse Trace inverse direction
+   */
+  transitiveClosure(
+      seeds: {
+          [uri: string]: boolean;
+      },
+      predicate: Node,
+      inverse: Node
+  ): {
+      [uri: string]: boolean;
+  };
+  /**
+   * Finds the types in the list which have no *stored* supertypes
+   * We exclude the universal class, owl:Things and rdf:Resource, as it is
+   * information-free.
+   * @param types The types
+   */
+  topTypeURIs(types: {
+      [id: string]: string | NamedNode;
+  }): {
+      [id: string]: string | NamedNode;
+  };
+  /**
+   * Gets the number of statements in this formulat that matches the specified pattern
+   * @param s The subject
+   * @param p The predicate
+   * @param o The object
+   * @param g The graph that contains the statement
+   */
+  whether(s: ValueType, p: ValueType, o: ValueType, g: ValueType): number;
+  /**
+   * Serializes this formulat to a string
+   */
+  toString(): string;
+  /**
+   * Gets a namespace for the specified namespace's URI
+   * @param nsuri The URI for the namespace
+   */
+  ns(nsuri: string): (ln: string) => NamedNode;
+  /**
+   * Gets a new variable
+   * @param name The variable's name
+   */
+  variable(name: string): Variable;
+  static termType: string;
+}
+/**
+* A formula (set of triples) which indexes by predicate, subject and object.
+* It "smushes"  (merges into a single node) things which are identical
+* according to owl:sameAs or an owl:InverseFunctionalProperty
+* or an owl:FunctionalProperty
+*/
+export class IndexedFormula extends Formula {
+  /**
+   * The number of statements in this formula
+   */
+  length: number;
+  /**
+   * Creates a new formula
+   * @param features The list of features to support
+   */
+  constructor(features: ReadonlyArray<string>);
+  /**
+   * Gets the URI of the default graph
+   */
+  static defaultGraphURI(): string;
+  /**
+   * Gets the statements matching the specified pattern
+   * @param subj The subject
+   * @param pred The predicate
+   * @param obj The object
+   * @param why The graph that contains the statement
+   * @param justOne Whether to only get one statement
+   */
+  statementsMatching(
+      subj: Node | null,
+      pred: Node | null,
+      obj: Node | null,
+      why: Node | null,
+      justOne?: boolean
+  ): Statement[];
+  /**
+   * Adds all the statements to this formula
+   * @param statements A collection of statements
+   */
+  addAll(statements: Iterable<Statement>): void;
+  /**
+   * Gets the value of a node that matches the specified pattern
+   * @param s The subject
+   * @param p The predicate
+   * @param o The object
+   * @param g The graph that contains the statement
+   */
+  anyValue(s: ValueType, p: ValueType, o: ValueType, g: ValueType): string;
+  /**
+   * Returns the symbol with canonical URI as smushed
+   * @param term A RDF node
+   */
+  canon(term: Node): Node;
+  /**
+   * Checks this formula for consistency
+   */
+  check(): void;
+  /**
+   * Checks a list of statements for consistency
+   * @param sts The list of statements to check
+   * @param from An index with the array ['subject', 'predicate', 'object', 'why']
+   */
+  checkStatementList(sts: ReadonlyArray<Statement>, from: number): boolean;
+  /**
+   * Closes this formula (and return it)
+   */
+  close(): IndexedFormula;
+  /**
+   * Simplify graph in store when we realize two identifiers are equivalent
+   * We replace the bigger with the smaller.
+   * @param u1 The first node
+   * @param u2 The second node
+   */
+  equate(u1: Node, u2: Node): boolean;
+  /**
+   * eturns any quads matching the given arguments.
+   * Standard RDFJS Taskforce method for Source objects, implemented as an
+   * alias to `statementsMatching()`
+   * @param subject The subject
+   * @param predicate The predicate
+   * @param object The object
+   * @param graph The graph that contains the statement
+   */
+  match(
+      subject: ValueType,
+      predicate: ValueType,
+      object: ValueType,
+      graph: ValueType
+  ): Statement[];
+  /**
+   * Find out whether a given URI is used as symbol in the formula
+   * @param uri The URI to look for
+   */
+  mentionsURI(uri: string): boolean;
+  /**
+   * Dictionary of namespace prefixes
+   */
+  namespaces: {[key: string]: string};
+  /**
+   * Existentials are BNodes - something exists without naming
+   * @param uri An URI
+   */
+  newExistential(uri: string): Node;
+  /**
+   * Creates a new universal node
+   * Universals are Variables
+   * @param uri An URI
+   */
+  newUniversal(uri: string): Node;
+  /**
+   * Find an unused id for a file being edited: return a symbol
+   * (Note: Slow iff a lot of them -- could be O(log(k)) )
+   * @param doc A document named node
+   */
+  nextSymbol(doc: NamedNode): NamedNode;
+  /**
+   * Removes a statement from this formula
+   * @param st A statement to remove
+   */
+  remove(st: Statement): IndexedFormula;
+  /**
+   * Removes all statemnts in a doc
+   * @param doc The document
+   */
+  removeDocument(doc: NamedNode): IndexedFormula;
+  /**
+   * Remove all statements matching args (within limit) *
+   * @param subj The subject
+   * @param pred The predicate
+   * @param obj The object
+   * @param why The graph that contains the statement
+   * @param limit The number of statements to remove
+   */
+  removeMany(
+      subj: Node,
+      pred: Node,
+      obj: Node,
+      why: Node,
+      limit: number
+  ): void;
+  /**
+   * Remove all matching statements
+   * @param subject The subject
+   * @param predicate The predicate
+   * @param object The object
+   * @param graph The graph that contains the statement
+   */
+  removeMatches(
+      subject: ValueType,
+      predicate: ValueType,
+      object: ValueType,
+      graph: ValueType
+  ): void;
+  /**
+   * Removes a statement
+   * @param st The statement to remove
+   */
+  removeStatement(st: Statement): Formula;
+  /**
+   * Removes statements
+   * @param sts The statements to remove
+   */
+  removeStatements(sts: ReadonlyArray<Statement>): Formula;
+  /**
+   * Return all equivalent URIs by which this is known
+   * @param x A named node
+   */
+  allAliases(x: NamedNode): NamedNode[];
+  /**
+   * Compare by canonical URI as smushed
+   * @param x A named node
+   * @param y Another named node
+   */
+  sameThings(x: NamedNode, y: NamedNode): boolean;
+  /**
+   * A list of all the URIs by which this thing is known
+   * @param term
+   */
+  uris(term: NamedNode): string[];
+}
+export namespace DataFactory {
+  /**
+   * Creates a new blank node
+   * @param value The blank node's identifier
+   */
+  function blankNode(value: string): BlankNode;
+  /**
+   * Creates a new collection
+   * @param elements The initial element
+   */
+  function collection(elements: ReadonlyArray<ValueType>): Collection;
+  /**
+   * Gets the default graph
+   */
+  function defaultGraph(): DefaultGraph;
+  /**
+   * Creates a new fetcher
+   * @param store The store to use
+   * @param options The options
+   */
+  function fetcher(store: Formula, options: any): Fetcher;
+  /**
+   * Creates a new graph (store)
+   */
+  function graph(): IndexedFormula;
+  /**
+   * Creates a new literal node
+   * @param val The lexical value
+   * @param lang The language
+   * @param dt The datatype
+   */
+  function lit(val: string, lang: string, dt: NamedNode): Literal;
+  /**
+   * Creates a new literal node
+   * @param value The lexical value
+   * @param languageOrDatatype Either the language or the datatype
+   */
+  function literal(
+      value: string,
+      languageOrDatatype: string | NamedNode
+  ): Literal;
+  /**
+   * Creates a new named node
+   * @param value The new named node
+   */
+  function namedNode(value: string): NamedNode;
+  /**
+   * Creates a new statement
+   * @param subject The subject
+   * @param predicate The predicate
+   * @param object The object
+   * @param graph The containing graph
+   */
+  function quad(
+      subject: Node,
+      predicate: Node,
+      object: Node,
+      graph: Node
+  ): Statement;
+  /**
+   * Creates a new statement
+   * @param subject The subject
+   * @param predicate The predicate
+   * @param object The object
+   * @param graph The containing graph
+   */
+  function st(
+      subject: Node,
+      predicate: Node,
+      object: Node,
+      graph: Node
+  ): Statement;
+  /**
+   * Creates a new statement
+   * @param subject The subject
+   * @param predicate The predicate
+   * @param object The object
+   */
+  function triple(subject: Node, predicate: Node, object: Node): Statement;
+  /**
+   * Creates a new variable
+   * @param name The name for the variable
+   */
+  function variable(name: string): Variable;
+}
+export namespace Util {
+  /**
+   * Gets a named node for a media type
+   * @param mediaType A media type
+   */
+  function mediaTypeClass(mediaType: string): NamedNode;
+  /**
+   * Gets a named node from the name of a relation
+   * @param relation The name of a relation
+   */
+  function linkRelationProperty(relation: string): NamedNode;
+  /**
+   * Loads ontologies of the data we load (this is the callback from the kb to
+   * the fetcher). Exports as `AJAR_handleNewTerm`
+   * @param kb The store
+   * @param p A property
+   * @param requestedBy
+   */
+  function AJAR_handleNewTerm(
+      kb: Formula,
+      p: NamedNode,
+      requestedBy: string
+  ): Promise<any>;
+}
+/**
+* A datatype-specific handler for fetching data
+*/
+export interface Handler {
+  response: any;
+  dom: any;
+}
+export interface FetchOptions {
+  fetch?: typeof fetch;
+  /**
+   * The resource which referred to this (for tracking bad links).
+   */
+  referringTerm?: NamedNode;
+  /**
+   * Provided content type (for writes).
+   */
+  contentType?: string;
+  /**
+   * Override the incoming header to force the data to be treated as this content-type (for reads).
+   */
+  forceContentType?: string;
+  /**
+   * Load the data even if loaded before. Also sets the `Cache-Control:` header to `no-cache`.
+   */
+  force?: boolean;
+  /**
+   * Original uri to preserve through proxying etc (`xhr.original`).
+   */
+  baseUri?: Node | string;
+  /**
+   * Whether this request is a retry via a proxy (generally done from an error handler).
+   */
+  proxyUsed?: boolean;
+  /**
+   * Flag for XHR/CORS etc
+   */
+  withCredentials?: boolean;
+  /**
+   * Before we parse new data, clear old, but only on status 200 responses.
+   */
+  clearPreviousData?: boolean;
+  /**
+   * Prevents the addition of various metadata triples (about the fetch request) to the store.
+   */
+  noMeta?: boolean;
+  noRDFa?: boolean;
+}
+/**
+* Responsible for fetching RDF data
+*/
+export class Fetcher {
+  store: any;
+  timeout: number;
+  appNode: BlankNode;
+  requested: {
+      [uri: string]: any;
+  };
+  timeouts: any;
+  redirectedTo: any;
+  constructor(store: any, options: any);
+  static HANDLERS: {
+      RDFXMLHandler: Handler;
+      XHTMLHandler: Handler;
+      XMLHandler: Handler;
+      HTMLHandler: Handler;
+      TextHandler: Handler;
+      N3Handler: Handler;
+  };
+  static CONTENT_TYPE_BY_EXT: {
+      [ext: string]: string;
+  };
+  /**
+   * Loads a web resource or resources into the store.
+   * @param uri Resource to load, provided either as a NamedNode object or a plain URL. If multiple resources are passed as an array, they will be fetched in parallel.
+   */
+  load: (uri: NamedNode[] | string[] | NamedNode | string, options?: FetchOptions) => Promise<Response>;
+}
+/**
+* Gets a node for the specified input
+* @param value An input value
+*/
+export function term(value: ValueType): Node | Collection | ValueType;
+/**
+* Gets a namespace
+* @param nsuri The URI for the namespace
+*/
+export function Namespace(nsuri: string): (ln: string) => NamedNode;
+/**
+* Transforms an NTriples string format into a Node.
+* The bnode bit should not be used on program-external values; designed
+* for internal work such as storing a bnode id in an HTML attribute.
+* This will only parse the strings generated by the vaious toNT() methods.
+* @param str A string representation
+*/
+export function fromNT(str: string): Node;
+/**
+* Creates a new fetcher
+* @param store The store to use
+* @param options The options
+*/
+export function fetcher(store: Formula, options: any): Fetcher;
+/**
+* Creates a new graph (store)
+*/
+export function graph(): IndexedFormula;
+/**
+* Creates a new literal node
+* @param val The lexical value
+* @param lang The language
+* @param dt The datatype
+*/
+export function lit(val: string, lang: string, dt: NamedNode): Literal;
+/**
+* Creates a new statement
+* @param subject The subject
+* @param predicate The predicate
+* @param object The object
+* @param graph The containing graph
+*/
+export function st(
+  subject: Node | Date | string,
+  predicate: Node,
+  object: Node | Date | string,
+  graph: Node
+): Statement;
+/**
+* Creates a new named node
+* @param value The new named node
+*/
+export function sym(value: string): NamedNode;
+/**
+* Creates a new variable
+* @param name The name for the variable
+*/
+export function variable(name: string): Variable;
+/**
+* Creates a new blank node
+* @param value The blank node's identifier
+*/
+export function blankNode(value: string): BlankNode;
+/**
+* Gets the default graph
+*/
+export function defaultGraph(): DefaultGraph;
+/**
+* Creates a new literal node
+* @param value The lexical value
+* @param languageOrDatatype Either the language or the datatype
+*/
+export function literal(
+  value: string,
+  languageOrDatatype: string | NamedNode
+): Literal;
+/**
+* Creates a new named node
+* @param value The new named node
+*/
+export function namedNode(value: string): NamedNode;
+/**
+* Creates a new statement
+* @param subject The subject
+* @param predicate The predicate
+* @param object The object
+* @param graph The containing graph
+*/
+export function quad(
+  subject: Node,
+  predicate: Node,
+  object: Node,
+  graph: Node
+): Statement;
+/**
+* Creates a new statement
+* @param subject The subject
+* @param predicate The predicate
+* @param object The object
+*/
+export function triple(subject: Node, predicate: Node, object: Node): Statement;
+/**
+* Parse a string and put the result into the graph kb.
+* Normal method is sync.
+* Unfortunately jsdonld is currently written to need to be called async.
+* Hence the mess below with executeCallback.
+* @param str The input string to parse
+* @param kb The store to use
+* @param base The base URI to use
+* @param contentType The content type for the input
+* @param callback The callback to call when the data has been loaded
+*/
+export function parse(
+  str: string,
+  kb: Formula,
+  base: string,
+  contentType: string,
+  callback: (error: any, kb: Formula) => void
+): void;
+/**
+* Get the next available unique identifier
+*/
+export let NextId: number;
+
+/**
+* The update manager is a helper object for a store.
+* Just as a Fetcher provides the store with the ability to read and write, the Update Manager provides functionality for making small patches in real time,
+* and also looking out for concurrent updates from other agents.
+*/
+export class UpdateManager {
+  /**
+   * @param store The quadstore to store data and metadata. Created if not passed.
+   */
+  constructor(store?: IndexedFormula)
+
+  /**
+   * This is suitable for an initial creation of a document.
+   * @param document
+   * @param data
+   * @param contentType
+   * @param callback
+   */
+  put(
+      document: Node,
+      data: string | Statement[],
+      contentType: string,
+      callback: (uri: string, ok: boolean, errorMessage: string, response?: unknown) => void,
+  ): Promise<void>;
+
+  /**
+   * This high-level function updates the local store iff the web is changed successfully.
+   * Deletions, insertions may be undefined or single statements or lists or formulae (may contain bnodes which can be indirectly identified by a where clause).
+   * The `why` property of each statement must be the same and give the web document to be updated.
+   * @param statementsToDelete Statement or statements to be deleted.
+   * @param statementsToAdd Statement or statements to be inserted.
+   * @param callback
+   */
+  update(
+      statementsToDelete: Statement[],
+      statementsToAdd: Statement[],
+      callback: (uri: string | undefined, success: boolean, errorBody?: string) => void
+  ): void;
+}
+}

--- a/typings/rdflib/index.d.ts
+++ b/typings/rdflib/index.d.ts
@@ -347,15 +347,15 @@ export class Statement {
   /**
    * The statement's subject
    */
-  subject: Node;
+  subject: NamedNode;
   /**
    * The statement's predicate
    */
-  predicate: Node;
+  predicate: NamedNode;
   /**
    * The statement's object
    */
-  object: Node;
+  object: NamedNode;
   /**
    * The origin of this statement
    */
@@ -1089,10 +1089,13 @@ export class Fetcher {
   static CONTENT_TYPE_BY_EXT: {
       [ext: string]: string;
   };
+<<<<<<< HEAD
   /**
    * Loads a web resource or resources into the store.
    * @param uri Resource to load, provided either as a NamedNode object or a plain URL. If multiple resources are passed as an array, they will be fetched in parallel.
    */
+=======
+>>>>>>> d6d756b... Show a Scratchpad's author
   load: (uri: NamedNode[] | string[] | NamedNode | string, options?: FetchOptions) => Promise<Response>;
 }
 /**

--- a/typings/rdflib/index.d.ts
+++ b/typings/rdflib/index.d.ts
@@ -741,6 +741,10 @@ export class IndexedFormula extends Formula {
    */
   length: number;
   /**
+   * An UpdateManager initialised to this store
+   */
+  updater?: UpdateManager;
+  /**
    * Creates a new formula
    * @param features The list of features to support
    */

--- a/typings/solid-namespace/index.d.ts
+++ b/typings/solid-namespace/index.d.ts
@@ -4,5 +4,5 @@ declare module 'solid-namespace' {
   type toNamedNode = (label: string) => NamedNode
   export type Namespaces = {[alias: string]: toNamedNode}
 
-  export default function vocab(store: IndexedFormula): Namespaces
+  export default function vocab(rdflib: typeof import('rdflib')): Namespaces
 }


### PR DESCRIPTION
(Builds on #106.)

This introduces a new Pad pane that can read Pads created by
the old one. It is intended as a testbed for experimenting with a
new setup for Panes in which their concerns are more clearly
separated. Specifically, it aims to achieve the following goals:

- Extract data access into a separate module. This potentially
  allows these modules to be re-used in other apps, to ensure
  data compatibility.
- Separate DOM manipulation from data manipulation. This makes it
  easier to update the view without risk of breaking something
  else.
- Add a wrapper to intermediate between the old and the new API.
  Hopefully we can let go of the old API in time, but that first
  requires more clarity on what needs to be preserved.
- Separate creation of new items from viewing them. Since the
  data model can be shared between different apps/panes, no single
  pane should be responsible for creating new instances, as that
  would be redundant with the equivalent methods in different
  panes.
- Separate item viewing from item discovery. Panes are responsible
  for viewing specific pieces of data (in this case: a notepad).
  This is useful for e.g. when a user is linked to a resource
  directly, allowing them to browse a specific piece of data.
  Discovering what data is available on one's Pod in general is a
  separate task - one could imagine e.g. a listing of simply all
  notepads in a Pod, sorted by date. Clicking one of those would
  bring you to the Scratchpad Pane.

This API is not final.

Note that it makes use of async/await, and therefore imports
@babel/polyfill. Because mashlib overwrites `require`, we cannot
yet include it globally, so the import has to be added to every
file using ES modules and async/await.