### PR TITLE
Publish branches as npm tags

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+# This file primarily exists to prevent ./dist from being ignored when publishing.
+# (Because it's listed in .gitignore).
+
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,15 @@ script:
   - npm test
   # Make sure it still builds successfully - the build isn't actually used yet:
   - npm run build
+before_deploy:
+  - node ./travis/bumpversion.js
+deploy:
+  provider: npm
+  # Do not throw away the updated package.json we generated in `before_deploy`:
+  skip_cleanup: true
+  email: "$NPM_EMAIL"
+  api_key: "$NPM_TOKEN"
+  # Note: do not deploy on pull request, because $TRAVIS_BRANCH will be the target branch.
+  tag: "$TRAVIS_BRANCH"
+  on:
+    all_branches: true

--- a/travis/bumpversion.js
+++ b/travis/bumpversion.js
@@ -1,0 +1,19 @@
+/**
+ * npm does not allow you to publish a package with the same version multiple times.
+ * Thus, to publish prerelease versions tagged to the branch they're built from,
+ * we need to generate unique version numbers that are also higher than versions already published.
+ * To achieve this, we append `build<build_number>` to the version number.
+ * The actual release version can eventually be published without the suffix.
+ */
+
+if (!process.env.TRAVIS_BUILD_NUMBER || process.env.TRAVIS_BUILD_NUMBER.length === 0) {
+  console.error('Could not read the build number to bump the package version - aborting publish.')
+  process.exit(1)
+}
+
+const fs = require('fs')
+const path = require('path')
+
+const packageJson = require('../package.json')
+packageJson.version = `${packageJson.version}build${process.env.TRAVIS_BUILD_NUMBER}`
+fs.writeFileSync(path.resolve(__dirname, '../package.json'), JSON.stringify(packageJson))


### PR DESCRIPTION
Although this does not yet add the ability to publish stable releases to npm from CI, this does publish every newly pushed branch to npm using that branch's name as the tag. This will allow us to test whether a package still works properly after it's published and built (which I'm currently somewhat unsure about, especially for the revamp).

As an example, you can now run `npm install solid-panes@95-ci-publish`.

**Important:** I created a new npm user specifically for this. I added the credentials for this account to the Inrupt password vault, but its email address is currently set to my own. Which email address would be more appropriate for this?

Note that this not prevent anyone who currently has publishing rights from publishing the way they did before.

Fixes #95, fixes #110 .