### PR TITLE
Adding solid-namespace directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mime-types": "^2.1.24",
     "pane-registry": "^1.0.4",
     "rdflib": "^0.20.1",
+    "solid-namespace": "^0.2.0",
     "solid-ui": "^0.12.2",
     "source-pane": "^1.0.3"
   },


### PR DESCRIPTION
Was added indirectly through solid-ui.

Perhaps not needed, but it's an annoyance with my local dev setup, so think it should be added directly.