### PR TITLE
Allow loading .ttl files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8922,6 +8922,28 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "raw-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-3.1.0.tgz",
+      "integrity": "sha512-lzUVMuJ06HF4rYveaz9Tv0WRlUMxJ0Y1hgSkkgg+50iEdaI0TthyEDe08KIHb0XsF6rn8WYTqPCaGTZg3sX+qA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.1.0.tgz",
+          "integrity": "sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "rdf-canonize": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "fork-ts-checker-webpack-plugin": "^1.3.0",
     "jest": "^24.8.0",
+    "raw-loader": "^3.1.0",
     "ts-jest": "^24.0.2",
     "typescript": "^3.4.5",
     "webpack": "^4.30.0",

--- a/profile/editProfilePane.source.ts
+++ b/profile/editProfilePane.source.ts
@@ -15,6 +15,8 @@ import { NamedNode } from 'rdflib'
 import { PaneDefinition } from '../types'
 import { getLabel } from './profilePaneUtils'
 
+import preferencesFormText from './preferencesFormText.ttl'
+
 const nodeMode = (typeof module !== 'undefined')
 
 // let panes: any
@@ -63,25 +65,6 @@ const thisPane: PaneDefinition = { // 'noun_638141.svg' not editing
     }
 
     function renderProfileForm (div: HTMLElement, subject: NamedNode) {
-      const preferencesFormText = `
-
-    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-    @prefix solid: <http://www.w3.org/ns/solid/terms#>.
-    @prefix ui: <http://www.w3.org/ns/ui#>.
-    @prefix : <#>.
-
-    :this
-      <http://purl.org/dc/elements/1.1/title> "Profile style form" ;
-      a ui:Form ;
-      ui:part :backgroundColor, :highlightColor;
-      ui:parts ( :backgroundColor :highlightColor ).
-
-  :backgroundColor a ui:ColorField; ui:property solid:profileBackgroundColor;
-    ui:label "Background color"; ui:default "#ffffff".
-    :highlightColor a ui:ColorField; ui:property solid:profileHighlightColor;
-      ui:label "Highlight color"; ui:default "#000000".
-
-  `
       const preferencesForm = kb.sym('https://solid.github.io/solid-panes/dashboard/profileStyle.ttl#this')
       const preferencesFormDoc = preferencesForm.doc()
       if (!kb.holds(undefined, undefined, undefined, preferencesFormDoc)) { // If not loaded already

--- a/profile/preferencesFormText.ttl
+++ b/profile/preferencesFormText.ttl
@@ -1,0 +1,17 @@
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix solid: <http://www.w3.org/ns/solid/terms#>.
+    @prefix ui: <http://www.w3.org/ns/ui#>.
+    @prefix : <#>.
+
+    :this
+      <http://purl.org/dc/elements/1.1/title> "Profile style form" ;
+      a ui:Form ;
+      ui:part :backgroundColor, :highlightColor;
+      ui:parts ( :backgroundColor :highlightColor ).
+
+  :backgroundColor a ui:ColorField; ui:property solid:profileBackgroundColor;
+    ui:label "Background color"; ui:default "#ffffff".
+    :highlightColor a ui:ColorField; ui:property solid:profileHighlightColor;
+      ui:label "Highlight color"; ui:default "#000000".
+
+  

--- a/typings/raw-loader.d.ts
+++ b/typings/raw-loader.d.ts
@@ -1,0 +1,4 @@
+declare module '*.ttl' {
+  const content: string
+  export default content
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,12 @@ module.exports = {
         use: {
           loader: 'babel-loader'
         }
+      },
+      {
+        test: /\.ttl$/i,
+        use: {
+          loader: 'raw-loader'
+        }
       }
     ]
   },


### PR DESCRIPTION
@timbl I've added the ability to import `.ttl` files into a Javascript file, which will automatically load the contents of the file into a Javascript variable. This is Webpack functionality, not official Javascript, so please double-check if that's desirable.

(Note that there also was a `versionInfo.js` file suddenly modified in this repo. Since I didn't know what that was, I did not include it in this commit. If it should be included, let me know @megoth.)