### PR TITLE
Add account deletion link(s) to preferences

### DIFF
--- a/dashboard/basicPreferences.source.ts
+++ b/dashboard/basicPreferences.source.ts
@@ -1,12 +1,14 @@
 import { PaneDefinition } from '../types'
 import UI from 'solid-ui'
-import { NamedNode, parse } from 'rdflib'
+import namespace from 'solid-namespace'
+import { NamedNode, parse, namedNode, IndexedFormula } from 'rdflib'
 import { renderTrustedApplicationsOptions } from './trustedApplications/trustedApplicationsPane'
 
 import preferencesFormText from './preferencesFormText.ttl'
 import ontologyData from './ontologyData.ttl'
 
 const kb = UI.store
+const ns = namespace({ namedNode } as any)
 
 export const basicPreferencesPane: PaneDefinition = {
   icon: UI.icons.iconBase + 'noun_Sliders_341315_000000.svg',
@@ -45,6 +47,7 @@ export const basicPreferencesPane: PaneDefinition = {
         console.log('Not doing private class preferences as no access to preferences file. ' + context.preferencesFileError)
         return
       }
+      addDeletionLinks(container, kb, context.me)
       const appendedForm = UI.widgets.appendForm(dom, formArea, {}, context.me, preferencesForm, context.preferencesFile, complainIfBad)
       appendedForm.style.borderStyle = 'none'
 
@@ -59,3 +62,61 @@ export const basicPreferencesPane: PaneDefinition = {
 
 export default basicPreferencesPane
 // ends
+
+function addDeletionLinks (container: HTMLElement, kb: IndexedFormula, profile: NamedNode): void {
+  const podServerNodes = kb.each(profile, ns.space('storage'), null, profile.doc())
+  const podServers = podServerNodes.map(node => node.value)
+  podServers.forEach(async (server) => {
+    const deletionLink = await generateDeletionLink(server)
+    if (deletionLink) {
+      container.appendChild(deletionLink)
+    }
+  })
+}
+
+async function generateDeletionLink (podServer: string): Promise<HTMLElement | null> {
+  const link = document.createElement('a')
+  link.textContent = `Delete your account at ${podServer}`
+  const deletionUrl = await getDeletionUrlForServer(podServer)
+  if (typeof deletionUrl !== 'string') {
+    return null
+  }
+  link.href = deletionUrl
+  return link
+}
+
+/**
+ * Hacky way to get the deletion link to a Pod
+ *
+ * This function infers the deletion link by assuming the URL structure of Node Solid server.
+ * In the future, Solid will hopefully provide a standardised way of discovering the deletion link:
+ * https://github.com/solid/data-interoperability-panel/issues/18
+ *
+ * If NSS is in multi-user mode (the case on inrupt.net and solid.community), the deletion URL for
+ * vincent.dev.inrupt.net would be at dev.inrupt.net/account/delete. In single-user mode, the
+ * deletion URL would be at vincent.dev.inrupt.net/account/delete.
+ *
+ * @param server Pod server containing the user's account.
+ * @returns URL of the page that Node Solid Server would offer to delete the account, or null if
+ *          the URLs we tried give invalid responses.
+ */
+async function getDeletionUrlForServer (server: string): Promise<string | null> {
+  const singleUserUrl = new URL(server)
+  const multiUserUrl = new URL(server)
+  multiUserUrl.pathname = singleUserUrl.pathname = '/account/delete'
+
+  const hostnameParts = multiUserUrl.hostname.split('.')
+  // Remove `vincent.` from `vincent.dev.inrupt.net`, for example:
+  multiUserUrl.hostname = hostnameParts.slice(1).join('.')
+
+  const multiUserNssResponse = await fetch(multiUserUrl.href, { method: 'HEAD' })
+  if (multiUserNssResponse.ok) {
+    return multiUserUrl.href
+  }
+
+  const singleUserNssResponse = await fetch(singleUserUrl.href, { method: 'HEAD' })
+  if (singleUserNssResponse.ok) {
+    return singleUserUrl.href
+  }
+  return null
+}


### PR DESCRIPTION
Note that this method assumes that the server is running Node Solid
Server, or at least provides the deletion link at
`/account/delete`.

It makes `HEAD` requests to what would be the deletion pages in single-user and multi-user Node Solid Server setups, respectively, as suggested at https://github.com/solid/solid-panes/issues/146#issuecomment-524858414.

Fixes #146.