### PR TITLE
Separating dashboard and outline

### DIFF
--- a/dashboard/dashboardPane.source.ts
+++ b/dashboard/dashboardPane.source.ts
@@ -33,7 +33,7 @@ function buildPage (container: HTMLElement, webId: NamedNode | null, dom: HTMLDo
 
 function buildDashboard (container: HTMLElement, dom: HTMLDocument) {
   const outliner = panes.getOutliner(dom)
-  outliner.showDashboard(container)
+  outliner.getDashboard().then((dashboard: HTMLElement) => container.appendChild(dashboard))
 }
 
 function buildHomePage (container: HTMLElement, subject: NamedNode) {

--- a/outline/manager.js
+++ b/outline/manager.js
@@ -386,14 +386,12 @@ module.exports = function (doc) {
     if (dashboardContainer.childNodes.length > 0 && options.pane) {
       outlineContainer.style.display = 'none'
       dashboardContainer.style.display = 'inherit'
-      const tab = dashboardContainer.querySelector(`[data-global-pane-name="${options.pane}"]`) ||
-        dashboardContainer.querySelector('[data-global-pane-name]')
+      const tab = dashboardContainer.querySelector(`[data-global-pane-name="${options.pane}"]`)
       if (tab) {
         tab.click()
         return
       }
-      console.warn('Found no tabs in global dashboard to open')
-      dashboardContainer.innerHTML = ''
+      console.warn('Did not find the referred tab in global dashboard, will open first one')
     }
 
     // create a new dashboard if not already present

--- a/outline/manager.js
+++ b/outline/manager.js
@@ -290,7 +290,7 @@ module.exports = function (doc) {
     const items = await getDashboardItems()
 
     function renderTab (div, item) {
-      div.dataset.name = item.tabName || item.paneName
+      div.dataset.globalPaneName = item.tabName || item.paneName
       div.textContent = item.label
     }
 
@@ -386,8 +386,8 @@ module.exports = function (doc) {
     if (dashboardContainer.childNodes.length > 0 && options.pane) {
       outlineContainer.style.display = 'none'
       dashboardContainer.style.display = 'inherit'
-      const tab = dashboardContainer.querySelector(`[data-name="${options.pane}"]`) ||
-        dashboardContainer.querySelector('[data-name]')
+      const tab = dashboardContainer.querySelector(`[data-global-pane-name="${options.pane}"]`) ||
+        dashboardContainer.querySelector('[data-global-pane-name]')
       if (tab) {
         tab.click()
         return

--- a/outline/manager.js
+++ b/outline/manager.js
@@ -271,10 +271,12 @@ module.exports = function (doc) {
     return predicateTD
   } // outlinePredicateTD
 
-/** Render Tabbed set of home app panes
+/**
+ * Render Tabbed set of home app panes
+ *
  * @param {Object} [options] A set of options you can provide
  * @param {string} [options.selectedTab] To open a specific dashboard pane
- * @returns Promise<{Element}> - the div
+ * @returns Promise<{Element}> - the div that holds the dashboard
 */
   async function globalAppTabs (options = {}) {
     console.log('globalAppTabs @@')
@@ -369,8 +371,8 @@ module.exports = function (doc) {
   this.getDashboardItems = getDashboardItems
 
   /**
+   * Call this method to show the global dashboard.
    *
-   * @param {HTMLElement} container The element that the dashboard should append dashboard to
    * @param {Object} [options] A set of options that can be passed
    * @param {string} [options.pane] To open a specific dashboard pane
    * @returns {Promise<void>}
@@ -424,6 +426,8 @@ module.exports = function (doc) {
 
   /**
    * Get element with id or create a new on the fly with that id
+   *
+   * @param {string} id The ID of the element you want to get or create
    * @returns {HTMLElement}
    */
   function getOrCreateContainer (id) {


### PR DESCRIPTION
No reason to reuse elements from the outline container that is used for displaying panes for a given subject.

This commit separates the logic for the two, and handles switching between them.

Not done any styling on cancel button, as I want to know how Tim wants to have it first.

This fixes https://github.com/solid/solid-panes/issues/154

This has some breaking changes in API that [mashlib](https://github.com/solid/mashlib/) uses, and mashlib will require these commit to continue functioning.