### PR TITLE
Reintroducing internalPane to all users

### DIFF
--- a/internal/internalPane.source.ts
+++ b/internal/internalPane.source.ts
@@ -17,8 +17,6 @@ const pane: PaneDefinition = {
 
   name: 'internal',
 
-  audience: [ns.solid('Developer')],
-
   label: function () {
     return 'under the hood' // There is often a URI even of no statements
   },


### PR DESCRIPTION
People can't delete files without this pane for now. We'll add another view for this later on, but add this as a quick fix for now.