### PR TITLE
add link icon for named nodes in default outline

### DIFF
--- a/src/outline/manager.js
+++ b/src/outline/manager.js
@@ -2347,6 +2347,8 @@ module.exports = function (context) {
         } else {
           // not tel:
           rep.appendChild(dom.createTextNode(UI.utils.label(obj)))
+          const anchor = UI.widgets.linkIcon(dom, obj)
+          rep.appendChild(anchor)
           UI.widgets.makeDraggable(rep, obj) // 2017
         }
       } else {

--- a/src/outline/manager.test.ts
+++ b/src/outline/manager.test.ts
@@ -56,6 +56,17 @@ describe('manager', () => {
         const label = getByText(result, 'namednode.example')
         expect(label).toHaveAttribute('draggable', 'true')
       })
+      describe('link icon', () => {
+        let linkIcon
+        beforeEach(() => {
+          const label = getByText(result, 'namednode.example')
+          linkIcon = label.lastChild
+        })
+        it('is linked to named node URI', () => {
+          expect(linkIcon.nodeName).toBe('A')
+          expect(linkIcon).toHaveAttribute('href', 'https://namednode.example/')
+        })
+      })
       describe('expanding', () => {
         it('renders relevant pane', async () => {
           const expand = result.firstChild


### PR DESCRIPTION
This PR adds a link icon next to each named node in the default view, as described in https://github.com/solid/solid-panes/issues/263

Preview:

![](https://user-images.githubusercontent.com/340725/101806484-4f415b00-3b14-11eb-9059-112add27769d.png)