### PR TITLE
Pass solid logic to pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-panes",
-  "version": "3.4.8",
+  "version": "3.5.0",
   "description": "Solid-compatible Panes: applets and views for the mashlib and databrowser",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "markdown-pane": "^0.1.1",
     "meeting-pane": "^2.3.4",
     "mime-types": "^2.1.28",
-    "pane-registry": "^2.3.5",
+    "pane-registry": "^2.4.1",
     "profile-pane": "^0.1.0",
     "rdflib": "^2.1.7",
     "react": "^17.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ export function getOutliner (dom) {
     const context = createContext(
       dom,
       { list, paneForIcon, paneForPredicate, register, byName },
-      UI.store as LiveStore
+            UI.store as LiveStore,
+            UI.solidLogicSingleton
     )
     dom.outlineManager = new OutlineManager(context)
   }

--- a/src/outline/context.ts
+++ b/src/outline/context.ts
@@ -1,17 +1,21 @@
 import { DataBrowserContext, LiveStore, PaneRegistry } from 'pane-registry'
 import { getOutliner } from '../index'
+import { solidLogicSingleton } from 'solid-ui'
+import { SolidLogic } from 'solid-logic'
 
 export function createContext (
   dom: HTMLDocument,
   paneRegistry: PaneRegistry,
-  store: LiveStore
+  store: LiveStore,
+  logic: SolidLogic
 ): DataBrowserContext {
   return {
     dom,
     getOutliner,
     session: {
       paneRegistry,
-      store
+      store,
+      logic
     }
   }
 }


### PR DESCRIPTION
finally pass solid logic to the panes via data browser session

This PR requires https://github.com/solid/pane-registry/pull/11 to be merged first, and pane-registry 2.4.0 to be available