### PR TITLE
Modification for Data-Kitchen

### DIFF
--- a/src/dashboard/dashboardPane.ts
+++ b/src/dashboard/dashboardPane.ts
@@ -18,9 +18,13 @@ export const dashboardPane: PaneDefinition = {
     const container = dom.createElement('div')
     const runBuildPage = () => {
       container.innerHTML = ''
+      let currentWebId = _solidUi.authn.authSession.info.webId;                 
+      let app = window.SolidAppContext;                                         
+      if( app.app && app.viewingNoAuthPage) currentWebId=app.webid;             
+      if( window.$SolidTestEnvironment && window.$SolidTestEnvironment.username) currentWebId=window.$SolidTestEnvironment.username;                           
       buildPage(
         container,
-        authn.authSession.info.webId ? sym(authn.authSession.info.webId) : null,
+        currentWebId ? sym(currentWebId) : null,
         context,
         subject
       )


### PR DESCRIPTION
If the user or app has set a webId for no-auth viewing and we are viewing a no-auth podroot, show the dashboard without checking for login status. For example, now the user's view of their private local pod will have the same dashboard as the logged in user - with pointers to their local profile, settings, and preferences and "MyStuff" links.  This does *not* implement my previous suggestion of letting the app create the home page, it simply treats a local home page the same as a logged in user.