### PR TITLE
minor modification for Data-Kitchen-like scenarios

### DIFF
--- a/src/dashboard/dashboardPane.ts
+++ b/src/dashboard/dashboardPane.ts
@@ -20,7 +20,7 @@ export const dashboardPane: PaneDefinition = {
       container.innerHTML = ''
       buildPage(
         container,
-        authn.authSession.info.webId ? sym(authn.authSession.info.webId) : null,
+        authn.currentUser() || null,
         context,
         subject
       )


### PR DESCRIPTION
Check authn.currentUser because we might be authorized to view  a private dashboard without authn.authSession.info.webId being set.