### PR TITLE
Refresh view after deleting folder

### DIFF
--- a/src/internal/internalPane.ts
+++ b/src/internal/internalPane.ts
@@ -8,6 +8,7 @@
 import { icons, ns, widgets } from 'solid-ui'
 import { BlankNode, IndexedFormula, literal, NamedNode, st, sym, Variable, Store } from 'rdflib'
 import { PaneDefinition } from 'pane-registry'
+import { UI } from '..'
 
 const pane: PaneDefinition = {
   icon: icons.originalIconBase + 'tango/22-emblem-system.png',
@@ -121,6 +122,7 @@ const pane: PaneDefinition = {
               .then(() => {
                 const str = 'Deleted: ' + subject
                 console.log(str)
+                UI.widgets.refreshTree(div.closest('.instancePane'))
               })
               .catch((err: any) => {
                 const str = 'Unable to delete ' + subject + ': ' + err


### PR DESCRIPTION
fix attempt for https://github.com/solid/solid-panes/issues/71
This fix goes across folder-pane too.
Together with PR: https://github.com/solid/folder-pane/pull/23
In the code I am making use of dom.closest() function which is compatible with all browsers accept IE which I think is ok: https://developer.mozilla.org/en-US/docs/Web/API/Element/closest