### PR TITLE
Fix homepage link to files

### DIFF
--- a/src/dashboard/homepage.ts
+++ b/src/dashboard/homepage.ts
@@ -30,7 +30,7 @@ function createDataSection (name: string): HTMLElement {
 
   const publicDataLink = document.createElement('a')
   publicDataLink.classList.add('list-group-item')
-  publicDataLink.href = window.document.location.href + "public/"
+  publicDataLink.href = window.document.location.href + 'public/'
   publicDataLink.innerText = `View ${name}'s files`
   listGroup.appendChild(publicDataLink)
 

--- a/src/dashboard/homepage.ts
+++ b/src/dashboard/homepage.ts
@@ -30,7 +30,7 @@ function createDataSection (name: string): HTMLElement {
 
   const publicDataLink = document.createElement('a')
   publicDataLink.classList.add('list-group-item')
-  publicDataLink.href = '/public/'
+  publicDataLink.href = window.document.location.href + "public/"
   publicDataLink.innerText = `View ${name}'s files`
   listGroup.appendChild(publicDataLink)
 


### PR DESCRIPTION
Currently a visitor not logged in sees a link to "user X's files" at user X's pod root.  The link is currently relative which breaks when the databrowser is not served as a server-front end (e.g. as a stand-alone webapp or in Data Kitchen).  This changes it to a full absolute URL.