### PR TITLE
Fix e.indexOf error and update webpack config

### DIFF
--- a/src/form/pane.js
+++ b/src/form/pane.js
@@ -90,7 +90,7 @@ module.exports = {
           const heading = dom.createElement('h4')
           box.appendChild(heading)
           if (form.uri) {
-            const formStore = $rdf.Util.uri.document(form)
+            const formStore = $rdf.Util.uri.document(form.uri)
             if (formStore.uri !== form.uri) {
               // The form is a hash-type URI
               const e = box.appendChild(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = [{
     '@trust/webcrypto': 'crypto'
   },
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    static: path.join(__dirname, 'dist'),
     compress: true,
     port: 9000
   },


### PR DESCRIPTION
Closes #319 where $rdf.Util.uri.document expects a string not a NamedNode.

Also updates webpack, which requires the parameter 'static' instead of 'contentBase'