### PR TITLE
Fix/errors using start

### DIFF
--- a/src/outline/manager.js
+++ b/src/outline/manager.js
@@ -7,7 +7,7 @@ import * as $rdf from 'rdflib'
 import * as UI from 'solid-ui'
 import { authn, authSession, store } from 'solid-logic'
 import propertyViews from './propertyViews'
-import * as license from './licenseOptions'
+import * as licenseOptions from './licenseOptions'
 
 const outlineIcons = require('./outlineIcons.js')
 const UserInput = require('./userInput.js')

--- a/src/outline/manager.js
+++ b/src/outline/manager.js
@@ -7,6 +7,7 @@ import * as $rdf from 'rdflib'
 import * as UI from 'solid-ui'
 import { authn, authSession, store } from 'solid-logic'
 import propertyViews from './propertyViews'
+import * as license from './licenseOptions'
 
 const outlineIcons = require('./outlineIcons.js')
 const UserInput = require('./userInput.js')
@@ -180,7 +181,7 @@ export default function (context) {
 
     // check the IPR on the data.  Ok if there is any checked license which is one the document has.
     if (statement && statement.why) {
-      if (UI.licenceOptions && UI.licenceOptions.checkLicence()) {
+      if (licenseOptions && licenseOptions.checkLicence()) {
         theClass += ' licOkay' // flag as light green etc .licOkay {background-color: #dfd}
       }
     }

--- a/src/socialPane.js
+++ b/src/socialPane.js
@@ -443,9 +443,9 @@ module.exports = {
         }
       }
     }
-    if ($rdf.keepThisCodeForLaterButDisableFerossConstantConditionPolice) {
+    /* if ($rdf.keepThisCodeForLaterButDisableFerossConstantConditionPolice) {
       triageFriends(s)
-    }
+    } */
     // //////////////////////////////////// Basic info on left
 
     h3 = dom.createElement('h3')


### PR DESCRIPTION
There are a few errors with functions etc not being found in outline/manager.js and also in socialPane.js when you run ```npm run start```.

It looked like licenseOptions was moved to solid-panes so we pointed to that instead of UI.licenseOptions
And we commented out the code for the other one because it didn't really seem needed at the moment.

we are waiting to here back regarding no_errors... function we left a comment in gitter.im