### PR TITLE
Avoid BlankNodes inside PATCHes

### DIFF
--- a/src/humanReadablePane.js
+++ b/src/humanReadablePane.js
@@ -6,7 +6,7 @@
 import { icons, ns } from 'solid-ui'
 import { Util } from 'rdflib'
 import { marked } from 'marked'
-import * as DOMPurify from 'dompurify'
+import DOMPurify from 'dompurify';
 
 const humanReadablePane = {
   icon: icons.originalIconBase + 'tango/22-text-x-generic.png',

--- a/src/trustedApplications/__snapshots__/trustedApplications.test.ts.snap
+++ b/src/trustedApplications/__snapshots__/trustedApplications.test.ts.snap
@@ -8,12 +8,10 @@ exports[`getStatementsToAdd should return all required statements to add the giv
       "termType": "NamedNode",
       "value": "https://profile.example",
     },
-    "object": BlankNode {
-      "classOrder": 6,
-      "isBlank": 1,
-      "isVar": 1,
-      "termType": "BlankNode",
-      "value": "bn_mock_app_id",
+    "object": NamedNode {
+      "classOrder": 5,
+      "termType": "NamedNode",
+      "value": "https://profile.example#mock_app_id",
     },
     "predicate": NamedNode {
       "classOrder": 5,
@@ -42,12 +40,10 @@ exports[`getStatementsToAdd should return all required statements to add the giv
       "termType": "NamedNode",
       "value": "http://www.w3.org/ns/auth/acl#origin",
     },
-    "subject": BlankNode {
-      "classOrder": 6,
-      "isBlank": 1,
-      "isVar": 1,
-      "termType": "BlankNode",
-      "value": "bn_mock_app_id",
+    "subject": NamedNode {
+      "classOrder": 5,
+      "termType": "NamedNode",
+      "value": "https://profile.example#mock_app_id",
     },
   },
   Statement {
@@ -66,12 +62,10 @@ exports[`getStatementsToAdd should return all required statements to add the giv
       "termType": "NamedNode",
       "value": "http://www.w3.org/ns/auth/acl#mode",
     },
-    "subject": BlankNode {
-      "classOrder": 6,
-      "isBlank": 1,
-      "isVar": 1,
-      "termType": "BlankNode",
-      "value": "bn_mock_app_id",
+    "subject": NamedNode {
+      "classOrder": 5,
+      "termType": "NamedNode",
+      "value": "https://profile.example#mock_app_id",
     },
   },
   Statement {
@@ -90,12 +84,10 @@ exports[`getStatementsToAdd should return all required statements to add the giv
       "termType": "NamedNode",
       "value": "http://www.w3.org/ns/auth/acl#mode",
     },
-    "subject": BlankNode {
-      "classOrder": 6,
-      "isBlank": 1,
-      "isVar": 1,
-      "termType": "BlankNode",
-      "value": "bn_mock_app_id",
+    "subject": NamedNode {
+      "classOrder": 5,
+      "termType": "NamedNode",
+      "value": "https://profile.example#mock_app_id",
     },
   },
 ]

--- a/src/trustedApplications/trustedApplications.utils.ts
+++ b/src/trustedApplications/trustedApplications.utils.ts
@@ -36,7 +36,7 @@ export function getStatementsToAdd (
   person: NamedNode,
   ns: Namespaces
 ): any {
-  const application = new NamedNode(nodeName)
+  const application = new NamedNode(`${person.doc().uri}#${nodeName}`)
   return [
     st(person, ns.acl('trustedApp'), application, person.doc()),
     st(application, ns.acl('origin'), origin, person.doc()),

--- a/src/trustedApplications/trustedApplications.utils.ts
+++ b/src/trustedApplications/trustedApplications.utils.ts
@@ -36,7 +36,7 @@ export function getStatementsToAdd (
   person: NamedNode,
   ns: Namespaces
 ): any {
-  const application = new BlankNode(`bn_${nodeName}`)
+  const application = new NamedNode(nodeName)
   return [
     st(person, ns.acl('trustedApp'), application, person.doc()),
     st(application, ns.acl('origin'), origin, person.doc()),


### PR DESCRIPTION
The spec [prohibits](https://solidproject.org/TR/protocol#server-patch-n3-blank-nodes) BlankNodes inside N3 PATCH entries, so let's use a NamedNode here?

Hopefully this can fix https://github.com/solid-contrib/pivot/issues/31

I haven't tested this code yet.