### PR TITLE
Fix TypeError when subject is not a NamedNode in dashboard pane

### DIFF
--- a/src/dashboard/dashboardPane.ts
+++ b/src/dashboard/dashboardPane.ts
@@ -8,8 +8,7 @@ export const dashboardPane: PaneDefinition = {
   icon: icons.iconBase + 'noun_547570.svg',
   name: 'dashboard',
   label: subject => {
-    console.log()
-    if (subject.uri === subject.site().uri) {
+    if (subject.termType === 'NamedNode' && subject.uri === subject.site().uri) {
       return 'Dashboard'
     }
     return null


### PR DESCRIPTION
## Summary
- Add type guard before calling `.site()` which only exists on NamedNode
- Removes stray `console.log()`

Fixes #227

## Test plan
This fix requires testing with the deployed databrowser to verify the dashboard pane no longer crashes on non-NamedNode subjects.