### PR TITLE
Change Node.js version to 20 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           name: build
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 20 # for npm@latest
           registry-url: 'https://registry.npmjs.org'
       - name: Update npm to latest (required for OIDC)
         run: npm install -g npm@latest


### PR DESCRIPTION
Updated Node.js version from 22 to 20 for compatibility with npm@latest.