### PR TITLE
Fix missing menu - use new auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solid-panes",
-  "version": "4.4.2-0",
+  "version": "4.4.2-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solid-panes",
-      "version": "4.4.2-0",
+      "version": "4.4.2-1",
       "license": "MIT",
       "dependencies": {
         "@solid/better-simple-slideshow": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-panes",
-  "version": "4.4.2-0",
+  "version": "4.4.2-1",
   "description": "Solid-compatible Panes: applets and views for the mashlib and databrowser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mainPage/menu.ts
+++ b/src/mainPage/menu.ts
@@ -456,26 +456,23 @@ export const createLeftSideMenu = async (subject: NamedNode, outliner: OutlineMa
         await renderMenuItems(subject, outliner, navMenuContent)
       }
 
-      authSession.events.on('login', () => {
-        void refreshAuthStateFromSession().then(() => {
-          updateMenuVisibility()
-          refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
-          void refreshMenuItems()
-        })
+      authSession.events.on('login', async () => {
+        await refreshAuthStateFromSession()
+        updateMenuVisibility()
+        refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
+        await refreshMenuItems()
       })
-      authSession.events.on('logout', () => {
-        void refreshAuthStateFromSession().then(() => {
-          updateMenuVisibility()
-          refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
-          void refreshMenuItems()
-        })
+      authSession.events.on('logout', async () => {
+        await refreshAuthStateFromSession()
+        updateMenuVisibility()
+        refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
+        await refreshMenuItems()
       })
-      authSession.events.on('sessionRestore', () => {
-        void refreshAuthStateFromSession().then(() => {
-          updateMenuVisibility()
-          refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
-          void refreshMenuItems()
-        })
+      authSession.events.on('sessionRestore', async () => {
+        await refreshAuthStateFromSession()
+        updateMenuVisibility()
+        refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
+        await refreshMenuItems()
       })
       navMenuContent.dataset.authEventsBound = 'true'
     }

--- a/src/mainPage/menu.ts
+++ b/src/mainPage/menu.ts
@@ -61,15 +61,12 @@ const applyMenuCollapsedState = (navMenu: HTMLElement | null): void => {
 
 const refreshAuthStateFromSession = async (): Promise<boolean> => {
   try {
-    await authn.checkUser()
-    if (!authn.currentUser()) {
-      await authn.checkUser()
-    }
-  } catch (error) {
+    const webId = await authn.checkUser()
+    return Boolean(webId || authn.currentUser())
+  } catch {
     // Keep the menu responsive even if auth refresh is transiently unavailable.
+    return Boolean(authn.currentUser())
   }
-
-  return Boolean(authn.currentUser())
 }
 
 const isLoggedIn = (): boolean => Boolean(authn.currentUser())

--- a/src/mainPage/menu.ts
+++ b/src/mainPage/menu.ts
@@ -59,7 +59,20 @@ const applyMenuCollapsedState = (navMenu: HTMLElement | null): void => {
   updateCollapseButtonPosition(navMenu, collapseBtn)
 }
 
-const isLoggedIn = (): boolean => Boolean(authSession?.info?.isLoggedIn)
+const refreshAuthStateFromSession = async (): Promise<boolean> => {
+  try {
+    await authn.checkUser()
+    if (!authn.currentUser()) {
+      await authn.checkUser()
+    }
+  } catch (error) {
+    // Keep the menu responsive even if auth refresh is transiently unavailable.
+  }
+
+  return Boolean(authn.currentUser())
+}
+
+const isLoggedIn = (): boolean => Boolean(authn.currentUser())
 
 const setFooterVisibility = (loggedIn: boolean): void => {
   const footer = document.querySelector('solid-ui-footer') as HTMLElement | null
@@ -343,6 +356,7 @@ export const createLeftSideMenu = async (subject: NamedNode, outliner: OutlineMa
   const menuToggle = document.getElementById('MenuToggleBtn') as HTMLElement | null
   const menuOverlay = document.getElementById('MenuOverlay') as HTMLElement | null
   const navMenuContent = document.getElementById('NavMenuContent') as HTMLElement | null
+  await refreshAuthStateFromSession()
 
   const closeMobileMenu = () => {
     if (!navMenu || !menuToggle || !menuOverlay) return
@@ -446,19 +460,25 @@ export const createLeftSideMenu = async (subject: NamedNode, outliner: OutlineMa
       }
 
       authSession.events.on('login', () => {
-        updateMenuVisibility()
-        refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
-        refreshMenuItems()
+        void refreshAuthStateFromSession().then(() => {
+          updateMenuVisibility()
+          refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
+          void refreshMenuItems()
+        })
       })
       authSession.events.on('logout', () => {
-        updateMenuVisibility()
-        refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
-        refreshMenuItems()
+        void refreshAuthStateFromSession().then(() => {
+          updateMenuVisibility()
+          refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
+          void refreshMenuItems()
+        })
       })
       authSession.events.on('sessionRestore', () => {
-        updateMenuVisibility()
-        refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
-        refreshMenuItems()
+        void refreshAuthStateFromSession().then(() => {
+          updateMenuVisibility()
+          refreshMenu(outliner.context?.environment?.layout === 'mobile' ? 'mobile' : 'desktop')
+          void refreshMenuItems()
+        })
       })
       navMenuContent.dataset.authEventsBound = 'true'
     }


### PR DESCRIPTION
use new auth for displaying side menu. isLoggedIn was no longer a dependable way of checking auth state, needed checkuser, also solid-logic is now async.